### PR TITLE
Attempt to fix #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,20 @@ Pre-requisite: You need Python 3+
 
 1. Clone [this repo](https://github.com/SathyaBhat/spotify-dl.git)
 2. Install dependencies using `pip install -r requirements.txt`
+ +  *Optional* (Using Virtualenv) 
+     - `pip install virtualenv`
+     - `cd my_project_folder` 
+     - `virtualenv venv`
+     
+     - `source venv/bin/activate`
 3. Enter your spotify userid in tokens.py
 4. Create your Spotify app & fetch the keys from [Spotify Developer Console](https://developer.spotify.com/my-applications/#!/applications). Paste the client id, secret, redirect URL in tokens.py. Note the redirect URL can be a valid URL, just ensure it matches with what you have entered in the developer console & in the script.
 5. Create your YouTube api & fetch the keys from [Google Developer Console](https://console.developers.google.com/apis/api/youtube/overview). Paste the keys in tokens.py.
-6. Run the script using `python spotify-dl`
+6. Run the script using `python spotify-dl.py`
 7. Click on the URL prompted to authenticate. Once logged in, paste the URL back in
 8. Once done, songs.txt should have list of YouTube URLs. Pass them to youtube-dl to have them downloaded. Please check [youtube-dl](https://rg3.github.io/youtube-dl/) documentation for more details. You also need ffmpeg or avconv installed.
+  - An example command to just get the mp3 from youtube-dl is
+    + `youtube-dl --extract-audio --audio-format mp3 -a songs.txt`
   - Linux users can get them by installing libav-tools by using apt-get (`sudo apt-get install -y libav-tools`) or a package manager which comes with your distro
   - Windowns users can download FFMPEG pre-built binaries from [here](http://ffmpeg.zeranoe.com/builds/). Extract the file using [7-zip](http://7-zip.org/) to a foldrer and [add the folder to your PATH environment variable](http://www.wikihow.com/Install-FFmpeg-on-Windows) 
 

--- a/spotify-dl.py
+++ b/spotify-dl.py
@@ -15,11 +15,22 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(prog='spotify-dl')
     parser.add_argument('-d', '--download', action='store_true', help='Download using youtube-dl')
     parser.add_argument('-V', '--verbose', action='store_true', help='Show more information on what''s happening.')
+    parser.add_argument('-o' , '--output',type=str,action='store',nargs='*',help='Specify download diretory.')
     args = parser.parse_args()
     if args.verbose:
         log.setLevel(logging.DEBUG)
 
     token = authenticate()
+    if args.output:
+        download_directory = args.output[0]
+            #Check whether directory has a trailing slash or not
+        if len(download_directory) >=0 and download_directory[-1] != '/':
+            download_directory+='/'
+    else:
+        download_directory=''
+    
+
+
     sp = spotipy.Spotify(auth=token)
     songs = fetch_saved_tracks(sp)
     url = []
@@ -29,4 +40,4 @@ if __name__ == '__main__':
             url.append(link)
     save_songs_to_file(url)
     if args.download == True:
-        download_songs(url)
+        download_songs(url,download_directory)

--- a/spotify.py
+++ b/spotify.py
@@ -41,7 +41,7 @@ def download_songs(songs):
     ydl_opts = {
         'format': 'bestaudio/best',
         'download_archive': 'downloaded_songs.txt',
-        'outtmpl': '%(title)s.%(ext)s',
+        'outtmpl': '~/Music/%(title)s.%(ext)s',
         'postprocessors': [{
             'key': 'FFmpegExtractAudio',
             'preferredcodec': 'mp3',

--- a/spotify.py
+++ b/spotify.py
@@ -9,7 +9,7 @@ import youtube_dl
 
 
 def authenticate():
-    return util.prompt_for_user_token(username,scope, CLIENT_ID, CLIENT_SECRET, REDIRECT_URL))
+    return util.prompt_for_user_token(username,scope, CLIENT_ID, CLIENT_SECRET, REDIRECT_URL)
 
 
 def fetch_saved_tracks(sp):

--- a/spotify.py
+++ b/spotify.py
@@ -9,7 +9,7 @@ import youtube_dl
 
 
 def authenticate():
-    return util.prompt_for_user_token(username,scope, CLIENT_ID, CLIENT_SECRET)
+    return util.prompt_for_user_token(username,scope, CLIENT_ID, CLIENT_SECRET, REDIRECT_URL))
 
 
 def fetch_saved_tracks(sp):

--- a/spotify.py
+++ b/spotify.py
@@ -9,7 +9,7 @@ import youtube_dl
 
 
 def authenticate():
-    return util.prompt_for_user_token(username,scope, CLIENT_ID, CLIENT_SECRET, REDIRECT_URL)
+    return util.prompt_for_user_token(username,scope, CLIENT_ID, CLIENT_SECRET)
 
 
 def fetch_saved_tracks(sp):
@@ -37,11 +37,11 @@ def save_songs_to_file(songs):
     f.close()
 
 
-def download_songs(songs):
+def download_songs(songs,download_directory):
     ydl_opts = {
         'format': 'bestaudio/best',
         'download_archive': 'downloaded_songs.txt',
-        'outtmpl': '~/Music/%(title)s.%(ext)s',
+        'outtmpl': download_directory+'%(title)s.%(ext)s',
         'postprocessors': [{
             'key': 'FFmpegExtractAudio',
             'preferredcodec': 'mp3',


### PR DESCRIPTION
youtube-dl has an -o option which can change the download directory as well. Changed to ~/Music/spotify-dl for now. Works in Linux, not sure about other OS.

Also added virtualenv instructions and an example youtube-dl instruction in README. 