### PR TITLE
Fix import statement sequeneces

### DIFF
--- a/spotify_dl/spotify.py
+++ b/spotify_dl/spotify.py
@@ -1,9 +1,11 @@
 from __future__ import unicode_literals
-from spotify_dl.scaffold import *
-import spotipy.util as util
-import youtube_dl
 import re
 import os
+
+import spotipy.util as util
+import youtube_dl
+
+from spotify_dl.scaffold import *
 
 
 def authenticate():

--- a/spotify_dl/spotify_dl.py
+++ b/spotify_dl/spotify_dl.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 import os
 from logging import DEBUG
+import argparse
+
+import spotipy
 
 from spotify_dl.scaffold import *
 from spotify_dl.spotify import authenticate
@@ -11,9 +14,6 @@ from spotify_dl.spotify import playlist_name
 from spotify_dl.youtube import fetch_youtube_url
 from spotify_dl.spotify import extract_user_and_playlist_from_uri
 from spotify_dl.spotify import get_playlist_name_from_id
-
-import spotipy
-import argparse
 
 
 def spotify_dl():

--- a/spotify_dl/youtube.py
+++ b/spotify_dl/youtube.py
@@ -1,10 +1,12 @@
+from os import getenv
+
 from googleapiclient.discovery import build
+
 from spotify_dl.constants import YOUTUBE_API_SERVICE_NAME
 from spotify_dl.constants import YOUTUBE_API_VERSION
 from spotify_dl.constants import VIDEO
 from spotify_dl.constants import YOUTUBE_VIDEO_URL
 from spotify_dl.scaffold import log
-from os import getenv
 
 
 def fetch_youtube_url(search_term):


### PR DESCRIPTION
Fixed import statement sequences: The usual convention is, first std lib imports, then installed lib imports and lastly local imports
