### PR TITLE
Hold spotipy to 2.3.8 to avoid unnecessary webbrowser dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Pre-requisite: You need Python 3+
 ###Credits
  - [rhnvrm](https://github.com/rhnvrm) for [adding in youtube-dl](https://github.com/SathyaBhat/spotify-dl/pull/1)
  - [mr-karan](https://github.com/mr-karan) for [adding save to directory](https://github.com/SathyaBhat/spotify-dl/pull/6)
- - [shantanugoel](https://github.com/SathyaBhat/spotify-dl/issues?q=is%3Apr+is%3Aopen+author%3Ashantanugoel) for adding in [User playlist support](https://github.com/SathyaBhat/spotify-dl/pull/7)
+ - [shantanugoel](https://github.com/shantanugoel) for adding in [User playlist support](https://github.com/SathyaBhat/spotify-dl/pull/7)
  - [sildur](https://github.com/sildur) for adding any [user playlist support and other fixes](https://github.com/SathyaBhat/spotify-dl/pulls?q=is%3Apr+author%3Asildur+is%3Aclosed)
  - [avinassh](https://github.com/avinassh) for being a [Rockstar](https://github.com/avinassh/rockstar) and not teleporting over to my house to kill me when I innundated him with questions
  - [doulwyi](https://github.com/doulwyi) for adding id3 tagging and ability to parse Spotify URI

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-spotipy>=2.3.7
+spotipy==2.3.8
 google-api-python-client==1.6.2
 youtube-dl>=2015.12.23


### PR DESCRIPTION
Newer spotipy releases don't work on headless installations due to this issue. Have created an issue for upstream at https://github.com/plamere/spotipy/issues/170

(PS: Also corrected my link in the README ;) )