### PR TITLE
Allow custom formats and make mp3 conversion optional

### DIFF
--- a/spotify_dl/spotify.py
+++ b/spotify_dl/spotify.py
@@ -69,7 +69,7 @@ def save_songs_to_file(songs, directory):
     f.close()
 
 
-def download_songs(info, download_directory, format_string, convert_to_mp3):
+def download_songs(info, download_directory, format_string, skip_mp3):
     """
     Downloads songs from the YouTube URL passed to either
        current directory or download_directory, is it is passed
@@ -89,7 +89,7 @@ def download_songs(info, download_directory, format_string, convert_to_mp3):
             ],
             'postprocessor_args': ['-metadata', 'title=' + str(track_)],
         }
-        if convert_to_mp3:
+        if not skip_mp3:
             mp3_postprocess_opts = {
                 'key': 'FFmpegExtractAudio',
                 'preferredcodec': 'mp3',

--- a/spotify_dl/spotify.py
+++ b/spotify_dl/spotify.py
@@ -69,7 +69,7 @@ def save_songs_to_file(songs, directory):
     f.close()
 
 
-def download_songs(info, download_directory):
+def download_songs(info, download_directory, format_string, convert_to_mp3):
     """
     Downloads songs from the YouTube URL passed to either
        current directory or download_directory, is it is passed
@@ -80,19 +80,22 @@ def download_songs(info, download_directory):
         download_archive = download_directory + 'downloaded_songs.txt'
         outtmpl = download_directory + '%(title)s.%(ext)s'
         ydl_opts = {
-            'format': 'bestaudio/best',
+            'format': format_string,
             'download_archive': download_archive,
             'outtmpl': outtmpl,
             'noplaylist': True,
             'postprocessors': [{
-                'key': 'FFmpegExtractAudio',
-                'preferredcodec': 'mp3',
-                'preferredquality': '192',
-            },
-                {'key': 'FFmpegMetadata'},
+                'key': 'FFmpegMetadata'},
             ],
             'postprocessor_args': ['-metadata', 'title=' + str(track_)],
         }
+        if convert_to_mp3:
+            mp3_postprocess_opts = {
+                'key': 'FFmpegExtractAudio',
+                'preferredcodec': 'mp3',
+                'preferredquality': '192',
+            }
+            ydl_opts['postprocessors'].append(mp3_postprocess_opts.copy())
 
         with youtube_dl.YoutubeDL(ydl_opts) as ydl:
             try:

--- a/spotify_dl/spotify_dl.py
+++ b/spotify_dl/spotify_dl.py
@@ -35,6 +35,11 @@ def spotify_dl():
                         ' is different than your spotify userid')
     parser.add_argument('-i', '--uri', type=str, action='store',
                         nargs='*', help='Given a URI, download it.')
+    parser.add_argument('-f', '--format_str', type=str, action='store',
+                        nargs='*', help='Specify youtube-dl format string.',
+                        default=['bestaudio/best'])
+    parser.add_argument('-m', '--mp3', action='store_true',
+                        help='Convert downloaded songs to mp3')
 
     args = parser.parse_args()
 
@@ -91,7 +96,7 @@ def spotify_dl():
 
     save_songs_to_file(url, download_directory)
     if args.download is True:
-        download_songs(url, download_directory)
+        download_songs(url, download_directory, args.format_str[0], args.mp3)
 
 
 if __name__ == '__main__':

--- a/spotify_dl/spotify_dl.py
+++ b/spotify_dl/spotify_dl.py
@@ -38,8 +38,8 @@ def spotify_dl():
     parser.add_argument('-f', '--format_str', type=str, action='store',
                         nargs='*', help='Specify youtube-dl format string.',
                         default=['bestaudio/best'])
-    parser.add_argument('-m', '--mp3', action='store_true',
-                        help='Convert downloaded songs to mp3')
+    parser.add_argument('-m', '--skip_mp3', action='store_true',
+                        help='Don\'t convert downloaded songs to mp3')
 
     args = parser.parse_args()
 
@@ -52,7 +52,7 @@ def spotify_dl():
 
     log.info('Starting spotify_dl')
     log.debug('setting debug mode on spotify_dl')
-    
+
     if not check_for_tokens():
         exit(1)
 
@@ -96,7 +96,7 @@ def spotify_dl():
 
     save_songs_to_file(url, download_directory)
     if args.download is True:
-        download_songs(url, download_directory, args.format_str[0], args.mp3)
+        download_songs(url, download_directory, args.format_str[0], args.skip_mp3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Scratching an itch for download part that I have for some time:
1. MP3 conversion is not always desired since it may take a long time for big playlists and is also sometimes not possible on all systems (hate the ugly warning messages for missing ffmpeg for those cases ;))
2. bestaudio downloads webm most of the time from youtube but most of the non-pc audio players (software as well as hw) can't play it, making mp3 a necessity. Added a way to use custom format strings for such cases (e.g. -f 'bestaudio[ext=m4a]/mp4' will download all songs in m4a natively which can be played by most players and is a pretty good quality format to boot).