### PR TITLE
Fix metadata addition to output files

### DIFF
--- a/spotify_dl/spotify.py
+++ b/spotify_dl/spotify.py
@@ -93,7 +93,7 @@ def download_songs(info, download_directory, format_string, skip_mp3):
                 'preferredcodec': 'mp3',
                 'preferredquality': '192',
             }
-            ydl_opts['postprocessors'].append(mp3_postprocess_opts.copy())
+            ydl_opts['postprocessors'] = [mp3_postprocess_opts.copy()]
 
         with youtube_dl.YoutubeDL(ydl_opts) as ydl:
             try:

--- a/spotify_dl/spotify.py
+++ b/spotify_dl/spotify.py
@@ -84,10 +84,8 @@ def download_songs(info, download_directory, format_string, skip_mp3):
             'download_archive': download_archive,
             'outtmpl': outtmpl,
             'noplaylist': True,
-            'postprocessors': [{
-                'key': 'FFmpegMetadata'},
-            ],
-            'postprocessor_args': ['-metadata', 'title=' + str(track_)],
+            'postprocessor_args': ['-metadata', 'title=' + str(track_),
+                                   '-metadata', 'artist=' + str(artist_)],
         }
         if not skip_mp3:
             mp3_postprocess_opts = {


### PR DESCRIPTION
Currently the "postprocessor_args" line for metadata addition does not take effect due to the "FFmpegMetdata" key added in postprocessors. The current code asks youtube-dl to pick metadata from the song title and add to the output file's tags. This has couple of issues:
- We are bound to data/format used by youtube-dl (e.g. cant add artist etc)
- youtube-dl/ffmpeg is making the "title" metadata as "artist - title".

This fix will allow to add the correct title and artist metadata to the output file.