### PR TITLE
specify utf-8 to fix writing file on windows

### DIFF
--- a/spotify_dl/spotify.py
+++ b/spotify_dl/spotify.py
@@ -64,7 +64,7 @@ def save_songs_to_file(songs, directory):
        to be downloaded from youtube-dl
     """
 
-    with open(os.path.join(directory, 'songs.txt'), 'w') as f:
+    with open(os.path.join(directory, 'songs.txt'), 'w', encoding="utf-8") as f:
         f.write(' '.join(str(songs)))
     f.close()
 


### PR DESCRIPTION
Python would throw a 'charmap' codec error when trying to write the songs.txt file on windows