### PR TITLE
fix: user_id error & support for playlist url with or without userid

### DIFF
--- a/spotify_dl/spotify.py
+++ b/spotify_dl/spotify.py
@@ -104,19 +104,24 @@ def download_songs(info, download_directory, format_string, skip_mp3):
                 continue
 
 
-def extract_user_and_playlist_from_uri(uri):
-    playlist_re = re.compile("spotify:user:[\w,.]+:playlist:[\w]+")
-    for playlist_uri in playlist_re.findall(uri):
+def extract_user_and_playlist_from_uri(uri, sp):
+    playlist_re = re.compile("(spotify)(:user:[\w,.]+)?(:playlist:[\w]+)")
+    user_id = sp.current_user()['id']
+    for playlist_uri in ["".join(x) for x in playlist_re.findall(uri)]:
         segments = playlist_uri.split(":")
-        user_id = segments[2]
-        log.info('List owner: ' + str(user_id))
-        playlist_id = segments[4]
-        log.info('List ID: ' + str(playlist_id))
+        if len(segments) >= 4:
+            user_id = segments[2]
+            playlist_id = segments[4]
+            log.info('List ID: ' + str(playlist_id))
+        else:
+            playlist_id = segments[2]
+            log.info('List ID: ' + str(playlist_id))
+    log.info('List owner: ' + str(user_id))
     return user_id, playlist_id
 
 
 def playlist_name(uri, sp):
-    user_id, playlist_id = extract_user_and_playlist_from_uri(uri)
+    user_id, playlist_id = extract_user_and_playlist_from_uri(uri, sp)
     return get_playlist_name_from_id(playlist_id, user_id, sp)
 
 

--- a/spotify_dl/spotify_dl.py
+++ b/spotify_dl/spotify_dl.py
@@ -82,7 +82,7 @@ def spotify_dl():
     else:
         raise Exception('Invalid playlist URL ')
     if args.uri:
-        current_user_id, playlist_id = extract_user_and_playlist_from_uri(args.uri[0])
+        current_user_id, playlist_id = extract_user_and_playlist_from_uri(args.uri[0], sp)
     else:
         if args.user_id is None:
             current_user_id = sp.current_user()['id']


### PR DESCRIPTION
### Changes made
* Modified regex to match playlist URL's with or without `user`
* Pass Current userid as default if `userid` not found in URL

#### Also fixes https://github.com/SathyaBhat/spotify-dl/issues/27


The current version of spotify_dl is breaking since it expects 
`https://open.spotify.com/user/gitpush/playlist/37i9dQZF1DWWF3yivn1m3D` while spotify application gives a playlist URL as 
`https://open.spotify.com/playlist/37i9dQZF1DWWF3yivn1m3D`

