### PR TITLE
Add album cover

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ youtube-dl>=2015.12.23
 sentry-sdk==0.14.1
 colorama==0.4.3
 click==7.0
+eyeD3==0.9.5

--- a/spotify_dl/spotify_dl.py
+++ b/spotify_dl/spotify_dl.py
@@ -41,6 +41,8 @@ def spotify_dl():
                         default='bestaudio/best')
     parser.add_argument('-m', '--skip_mp3', action='store_true',
                         help='Don\'t convert downloaded songs to mp3')
+    parser.add_argument('-c', '--add_cover', action='store_true', default=False,
+                        help='Add album cover from Spotify to downloaded songs')
     parser.add_argument('-l', '--url', action="store",
                         help="Spotify Playlist link URL")
 
@@ -112,14 +114,14 @@ def spotify_dl():
     else:
         songs = fetch_tracks(sp, args.playlist, current_user_id)
     url = []
-    for song, artist in songs.items():
-        link = fetch_youtube_url(song + ' - ' + artist, get_youtube_dev_key())
+    for name, artist, cover in songs:
+        link = fetch_youtube_url(name + ' - ' + artist, get_youtube_dev_key())
         if link:
-            url.append((link, song, artist))
+            url.append((link, name, artist, cover))
 
     save_songs_to_file(url, download_directory)
     if args.download is True:
-        download_songs(url, download_directory, args.format_str, args.skip_mp3)
+        download_songs(url, download_directory, args.format_str, args.skip_mp3, args.add_cover)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Not sure if it's a feature wanted/needed but I use it 😬 

`--add_cover` downloads the album cover image from Spotify and adds it to the file's metadata. By default this is set to False so it doesn't change the script behaviour.

<img width="512" alt="Screenshot 2020-04-24 at 3 54 01 PM" src="https://user-images.githubusercontent.com/1789007/80229354-94318380-8650-11ea-8959-d7e7eaf18049.png">
  