### PR TITLE
Add Track Tagging with id3

### DIFF
--- a/spotify_dl/spotify.py
+++ b/spotify_dl/spotify.py
@@ -74,7 +74,7 @@ def download_songs(info, download_directory, format_string, skip_mp3):
     Downloads songs from the YouTube URL passed to either
        current directory or download_directory, is it is passed
     """
-    for item in info:
+    for number, item in enumerate(info):
         log.debug('Songs to download: %s', item)
         url_, track_, artist_ = item
         download_archive = download_directory + 'downloaded_songs.txt'
@@ -85,7 +85,8 @@ def download_songs(info, download_directory, format_string, skip_mp3):
             'outtmpl': outtmpl,
             'noplaylist': True,
             'postprocessor_args': ['-metadata', 'title=' + str(track_),
-                                   '-metadata', 'artist=' + str(artist_)],
+                                   '-metadata', 'artist=' + str(artist_),
+                                   '-metadata', 'track=' + str(number + 1)]
         }
         if not skip_mp3:
             mp3_postprocess_opts = {


### PR DESCRIPTION
Adding the TRCK header (Ffmpeg metadata tag's "track") parameter would be helpful to organize the resulting playlist, especially for playlists with a lot of songs.

For example, the TRCK tag is what determines the order in applications like [cmus](https://cmus.github.io/):
![image](https://user-images.githubusercontent.com/20411956/82634578-05bb0e00-9bcc-11ea-9a95-ea8e4e6a7cf7.png)

If I'm reading the code right, it should be as simple as this:
Assuming the songs are downloaded in order, then adding a number variable should work.
(file spotify_dl/spotify.py, lines 77-90)
```python
    for number, item in enumerate(info):
        log.debug('Songs to download: %s', item)
        url_, track_, artist_ = item
        download_archive = download_directory + 'downloaded_songs.txt'
        outtmpl = download_directory + '%(title)s.%(ext)s'
        ydl_opts = {
            'format': format_string,
            'download_archive': download_archive,
            'outtmpl': outtmpl,
            'noplaylist': True,
            'postprocessor_args': ['-metadata', 'title=' + str(track_),
                                   '-metadata', 'artist=' + str(artist_),
                                   '-metadata', 'track=' + str(number + 1)]
        }
```

A bit of basic testing seems to work.
