### PR TITLE
Update spotify.py

### DIFF
--- a/spotify_dl/spotify.py
+++ b/spotify_dl/spotify.py
@@ -25,7 +25,7 @@ def fetch_tracks(sp, playlist, user_id):
                                               limit=50, offset=offset)
 
         log.debug(f'Got result json keys {results.keys()}', )
-        for item in results['items']:
+        for item in results['tracks']['items']:
             track = item['track']
 
             if track is not None:


### PR DESCRIPTION
API now appears to nest the json results under 
"tracks:": { "items": [...tracks here...] } 
rather than just  
"items": [...tracks here...] } 
which was resulting in a KeyError