### PR TITLE
Help users know what's wrong if they make the natural mistake of using a Spotiify URI instead of a Spotify link

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,5 +11,6 @@ spotify_dl wouldn't be what it is without the help and contributions of followin
  - [Gowtham](https://github.com/HackToHell) for [create playlist in download](https://github.com/SathyaBhat/spotify-dl/pull/23) directory
  - [alvierahman90](https://github.com/alvierahman90) for [config file support](https://github.com/SathyaBhat/spotify-dl/pull/42) and [Spotify playlist URL support](https://github.com/SathyaBhat/spotify-dl/pull/41)
  - [Bibhas](https://github.com/iambibhas) for fixing [can only concatenate list (not "str") to list error](https://github.com/SathyaBhat/spotify-dl/issues/44)
- - [Nikhil Nagaraju](https://github.com/nikhilnagaraju) for fixing support for playlist url with or without userid #58
- - [Luca]https://github.com/lucanello) for adding [YouTube scraping support](https://github.com/SathyaBhat/spotify-dl/pull/75)
+ - [Nikhil Nagaraju](https://github.com/nikhilnagaraju) for fixing support for [playlist url with or without userid](https://github.com/SathyaBhat/spotify-dl/pull/58)
+ - [Luca](https://github.com/lucanello) for adding [YouTube scraping support](https://github.com/SathyaBhat/spotify-dl/pull/75)
+ - [Paul Bissex](https://github.com/pbx) for [better error description](https://github.com/SathyaBhat/spotify-dl/pull/138)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-spotipy==2.16
+spotipy== 2.16.1
 youtube-dl>=2020.11.29
 sentry-sdk==0.19.4
 wheel==0.34.2

--- a/spotify_dl/spotify.py
+++ b/spotify_dl/spotify.py
@@ -1,3 +1,4 @@
+import sys
 from spotify_dl.scaffold import log
 from spotify_dl.utils import sanitize
 
@@ -59,6 +60,9 @@ def parse_spotify_url(url):
     :param format_string: format string for the file conversion
     :return tuple indicating the type and id of the item
     """
+    if url.startswith("spotify:"):
+        log.error("Spotify URI was provided instead of a playlist/album/track URL.")
+        sys.exit(1)
     parsed_url = url.replace("https://open.spotify.com/", "")
     item_type = parsed_url.split("/")[0]
     item_id = parsed_url.split("/")[1]


### PR DESCRIPTION
Thanks for the software! I'm offering this PR as a possible UX improvement.

I made this mistake when I was trying out this app for the first time today. Running current `master` (`44cf2d3`), here's the output you get if you provide a Spotify URI like `spotify:playlist:0wMH0M981nj70CQLzF1CzJ` instead of a "Spotify link" as they call them:

```
Starting spotify_dl
Traceback (most recent call last):
  File ".../bin//spotify_dl", line 8, in <module>
    sys.exit(spotify_dl())
  File ".../spotify_dl/spotify_dl.py", line 69, in spotify_dl
    valid_item = validate_spotify_url(args.url)
  File ".../spotify_dl/spotify.py", line 90, in validate_spotify_url
    item_type, item_id = parse_spotify_url(url)
  File ".../spotify_dl/spotify.py", line 64, in parse_spotify_url
    item_id = parsed_url.split("/")[1]
IndexError: list index out of range
Sentry is attempting to send 0 pending error messages
Waiting up to 2 seconds
Press Ctrl-C to quit
```
I figured a one-line error message would be more helpful and friendly.