### PR TITLE
Basic Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# Use an official Python runtime as a base image
+FROM python:3.8-slim
+
+# Install any needed packages specified in requirements.txt
+RUN apt-get update
+RUN apt-get install -y ffmpeg
+RUN pip3 install spotify_dl --upgrade
+
+# Define environment variable
+ENV SPOTIPY_CLIENT_ID=
+ENV SPOTIPY_CLIENT_SECRET=

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -37,6 +37,22 @@ Pre-requisite: You need Python 3.6+
   - Linux users can get them by installing libav-tools by using apt-get (`sudo apt-get install -y libav-tools`) or a package manager which comes with your distro
   - Windows users can download FFMPEG pre-built binaries from [here](http://ffmpeg.zeranoe.com/builds/). Extract the file using [7-zip](http://7-zip.org/) to a foldrer and [add the folder to your PATH environment variable](http://www.wikihow.com/Install-FFmpeg-on-Windows) 
   
+### Use Docker
+
+Build the Docker image from the Dockerfile, run the following command in the spotify_dl root directory: `docker build -t spotify_dl .`
+
+Run the Docker image with your client ID and secret:
+``` bash
+docker run -d --rm \
+		   -e SPOTIPY_CLIENT_ID=client_id \
+		   -e SPOTIPY_CLIENT_SECRET=client_secret \
+		   -v "`pwd`":/download \
+		   spotify_dl \
+		   spotify_dl -l "spotify_playlist_link" -o download_directory
+```
+
+You can also run the bulk downloading script, make sure to configure it first: `bash bulk_docker_download.sh`
+
 ### How do I set defaults?
 
 You can set defaults per user by creating a file at `~/.spotify_dl_settings`. Create a key with value for every argument you want a default for. Example:

--- a/bulk_docker_download.sh
+++ b/bulk_docker_download.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+# Information: The docker image has to be previously built and tagged with spotify_dl[:latest]
+# Use 'docker build -t spotify_dl .' inside the project directory to build the Docker container
+
+# Specify download location, use pwd for current directory
+location="`pwd`"
+
+# Declare list with playlists to download
+declare -a playlists=( \
+	"https://open.spotify.com/PLAYLIST_LINK" "Playlist Name" \
+	"https://open.spotify.com/PLAYLIST_LINK" "Playlist Name" \
+)
+
+# Set client ID and secret
+client_id=sampleid123
+client_secret=samplesecret123
+
+arraylength=${#playlists[@]}
+
+for (( i=1; i<${arraylength}+1; i=i+2 ));
+do
+	echo "Downloading playlist: ${playlists[$i-1]}"
+	path="$location/${playlists[$i]}"
+	echo "Creating dir: $path"
+	mkdir -p "$path"
+	echo "Starting container: " $(echo "spotify_dl-${playlists[$i]//[^[:alnum:]]/}" | sed 's/ä/ae/;s/ö/oe/;s/ü/ue/;s/ß/ss/g')
+	docker run -d --rm --name $(echo "spotify_dl-${playlists[$i]//[^[:alnum:]]/}" | sed 's/ä/ae/;s/ö/oe/;s/ü/ue/;s/ß/ss/g') \
+		   -e SPOTIPY_CLIENT_ID=$client_id \
+		   -e SPOTIPY_CLIENT_SECRET=$client_secret \
+		   -v "$location":/download \
+		   spotify_dl \
+		   spotify_dl -l "${playlists[$i-1]}" -o /download &
+done


### PR DESCRIPTION
This PR adds a basic Dockerfile for building a spotify_dl image and a simple bash script for parallel bulk downloading of Spotify playlists.

Please note: the Dockerfile doesn't need to be changed. The environment variables for the client ID and secret are there for placeholder purposes.
You can choose whether you want them to be included in the self-built Docker image (not suggested!) or you want to pass them when running a container.