### PR TITLE
Add support for playlist track number

### DIFF
--- a/spotify_dl/spotify.py
+++ b/spotify_dl/spotify.py
@@ -38,7 +38,7 @@ def fetch_tracks(sp, item_type, url):
                 else:
                     genre = ""
                 songs_list.append({"name": track_name, "artist": track_artist, "album": track_album, "year": track_year,
-                                   "num_tracks": album_total, "num": track_num,
+                                   "num_tracks": album_total, "num": track_num, "playlist_num": offset + 1,
                                    "cover": cover, "genre": genre})
                 offset += 1
 
@@ -65,7 +65,7 @@ def fetch_tracks(sp, item_type, url):
                 track_artist = ", ".join([artist['name'] for artist in item['artists']])
                 track_num = item['track_number']
                 songs_list.append({"name": track_name, "artist": track_artist, "album": track_album, "year": track_year,
-                                   "num_tracks": album_total, "num": track_num,
+                                   "num_tracks": album_total, "num": track_num, "playlist_num": offset + 1,
                                    "cover": cover, "genre": genre})
                 offset += 1
 
@@ -88,7 +88,7 @@ def fetch_tracks(sp, item_type, url):
         else:
             genre = ""
         songs_list.append({"name": track_name, "artist": track_artist, "album": track_album, "year": track_year,
-                           "num_tracks": album_total, "num": track_num,
+                           "num_tracks": album_total, "num": track_num, "playlist_num": offset + 1,
                            "cover": cover, "genre": genre})
 
     return songs_list

--- a/spotify_dl/spotify_dl.py
+++ b/spotify_dl/spotify_dl.py
@@ -28,6 +28,9 @@ def spotify_dl():
     parser.add_argument('-f', '--format_str', type=str, action='store',
                         help='Specify youtube-dl format string.',
                         default='bestaudio/best')
+    parser.add_argument('-k', '--keep_playlist_order', type=bool, default=False,
+                        action=argparse.BooleanOptionalAction,
+                        help='Whether to keep original playlist ordering or not.')
     parser.add_argument('-m', '--skip_mp3', action='store_true',
                         help='Don\'t convert downloaded songs to mp3')
     parser.add_argument('-s', '--scrape', action="store",
@@ -81,7 +84,7 @@ def spotify_dl():
 
     songs = fetch_tracks(sp, item_type, args.url)
     if args.download is True:
-        download_songs(songs, save_path, args.format_str, args.skip_mp3)
+        download_songs(songs, save_path, args.format_str, args.skip_mp3, args.keep_playlist_order)
 
 
 if __name__ == '__main__':

--- a/spotify_dl/youtube.py
+++ b/spotify_dl/youtube.py
@@ -9,19 +9,25 @@ from mutagen.mp3 import MP3
 from spotify_dl.scaffold import log
 
 
-def download_songs(songs, download_directory, format_string, skip_mp3):
+def download_songs(songs, download_directory, format_string, skip_mp3, keep_playlist_order=False):
     """
     Downloads songs from the YouTube URL passed to either current directory or download_directory, is it is passed.
     :param songs: Dictionary of songs and associated artist
     :param download_directory: Location where to save
     :param format_string: format string for the file conversion
     :param skip_mp3: Whether to skip conversion to MP3
+    :param keep_playlist_order: Whether to keep original playlist ordering. Also, prefixes songs files with playlist num
     """
     log.debug(f"Downloading to {download_directory}")
     for song in songs:
         query = f"{song.get('artist')} - {song.get('name')} Lyrics".replace(":", "").replace("\"", "")
         download_archive = path.join(download_directory, 'downloaded_songs.txt')
-        outtmpl = path.join(download_directory, f"{song.get('artist')} - {song.get('name')}.%(ext)s")
+        if keep_playlist_order:
+            file_path = path.join(download_directory,
+                                  f"{song.get('playlist_num')} - {song.get('artist')} - {song.get('name')}")
+        else:
+            file_path = path.join(download_directory, f"{song.get('artist')} - {song.get('name')}")
+        outtmpl = f"{file_path}.%(ext)s"
         ydl_opts = {
             'format': format_string,
             'download_archive': download_archive,
@@ -49,13 +55,16 @@ def download_songs(songs, download_directory, format_string, skip_mp3):
                 continue
 
         if not skip_mp3:
-            song_file = MP3(path.join(download_directory, f"{song.get('artist')} - {song.get('name')}.mp3"),
+            song_file = MP3(path.join(f"{file_path}.mp3"),
                             ID3=EasyID3)
             song_file['date'] = song.get('year')
-            song_file['tracknumber'] = str(song.get('num')) + '/' + str(song.get('num_tracks'))
+            if keep_playlist_order:
+                song_file['tracknumber'] = str(song.get('playlist_num'))
+            else:
+                song_file['tracknumber'] = str(song.get('num')) + '/' + str(song.get('num_tracks'))
             song_file['genre'] = song.get('genre')
             song_file.save()
-            song_file = MP3(path.join(download_directory, f"{song.get('artist')} - {song.get('name')}.mp3"),
+            song_file = MP3(path.join(f"{file_path}.mp3"),
                             ID3=ID3)
             song_file.tags['APIC'] = APIC(
                 encoding=3,
@@ -64,4 +73,3 @@ def download_songs(songs, download_directory, format_string, skip_mp3):
                 data=urllib.request.urlopen(song.get('cover')).read()
             )
             song_file.save()
-            


### PR DESCRIPTION
First of all, thanks @SathyaBhat for creating this tool!

This PR adds an option to keep original playlist ordering in track mp3 metadata. Also, prefixes songs files with this playlist track number.

I chose to not increment playlist number depending of youtube-dl success. Thus, a missing song number in the playlist directory will allow the user to spot youtube-dl failures.

