### PR TITLE
Partial revert bad merge of da805a4

### DIFF
--- a/spotify_dl/youtube.py
+++ b/spotify_dl/youtube.py
@@ -66,8 +66,7 @@ def download_songs(songs, download_directory, format_string, skip_mp3, keep_play
                 song_file['tracknumber'] = str(song.get('num')) + '/' + str(song.get('num_tracks'))
             song_file['genre'] = song.get('genre')
             song_file.save()
-            song_file = MP3(path.join(download_directory, f"{song.get('artist')} - {song.get('name')}.mp3"),
-                            ID3=ID3)
+            song_file = MP3(f"{file_path}.mp3", ID3=ID3)
             if song.get('cover') is not None:
                 song_file.tags['APIC'] = APIC(
                     encoding=3,


### PR DESCRIPTION
Fixing https://github.com/SathyaBhat/spotify-dl/issues/157

Bad merge of da805a4 broke 34ad664. Now, mutagen metadata processing is failing when downloading without using `-k` option.