### PR TITLE
Dynamically expose file_name function in download_songs

### DIFF
--- a/spotify_dl/spotify.py
+++ b/spotify_dl/spotify.py
@@ -22,7 +22,8 @@ def fetch_tracks(sp, item_type, url):
                                       fields='items.track.name,items.track.artists(name, uri),'
                                              'items.track.album(name, release_date, total_tracks, images),'
 
-                                             'items.track.track_number,total, next,offset',
+                                             'items.track.track_number,total, next,offset,'
+                                             'items.track.id',
                                       additional_types=['track'], offset=offset)
             total_songs = items.get('total')
             for item in items['items']:
@@ -32,6 +33,7 @@ def fetch_tracks(sp, item_type, url):
                 track_year = item['track']['album']['release_date'][:4]
                 album_total = item['track']['album']['total_tracks']
                 track_num = item['track']['track_number']
+                spotify_id = item['track']['id']
                 if len(item['track']['album']['images']) > 0:
                     cover = item['track']['album']['images'][0]['url']
                 else:
@@ -43,7 +45,7 @@ def fetch_tracks(sp, item_type, url):
                     genre = ""
                 songs_list.append({"name": track_name, "artist": track_artist, "album": track_album, "year": track_year,
                                    "num_tracks": album_total, "num": track_num, "playlist_num": offset + 1,
-                                   "cover": cover, "genre": genre})
+                                   "cover": cover, "genre": genre, "spotify_id": spotify_id})
                 offset += 1
 
             log.info(f"Fetched {offset}/{total_songs} songs in the playlist")
@@ -71,9 +73,10 @@ def fetch_tracks(sp, item_type, url):
                 track_name = item['name']
                 track_artist = ", ".join([artist['name'] for artist in item['artists']])
                 track_num = item['track_number']
+                spotify_id = item['id']
                 songs_list.append({"name": track_name, "artist": track_artist, "album": track_album, "year": track_year,
                                    "num_tracks": album_total, "num": track_num, "playlist_num": offset + 1,
-                                   "cover": cover, "genre": genre})
+                                   "cover": cover, "genre": genre, "spotify_id": spotify_id})
                 offset += 1
 
             log.info(f"Fetched {offset}/{total_songs} songs in the album")
@@ -89,6 +92,7 @@ def fetch_tracks(sp, item_type, url):
         track_year = items['album']['release_date'][:4]
         album_total = items['album']['total_tracks']
         track_num = items['track_number']
+        spotify_id = items['id']
         if len(items['album']['images']) > 0:
             cover = items['album']['images'][0]['url']
         else:
@@ -99,7 +103,7 @@ def fetch_tracks(sp, item_type, url):
             genre = ""
         songs_list.append({"name": track_name, "artist": track_artist, "album": track_album, "year": track_year,
                            "num_tracks": album_total, "num": track_num, "playlist_num": offset + 1,
-                           "cover": cover, "genre": genre})
+                           "cover": cover, "genre": genre, "spotify_id": spotify_id})
 
     return songs_list
 

--- a/spotify_dl/spotify_dl.py
+++ b/spotify_dl/spotify_dl.py
@@ -28,8 +28,8 @@ def spotify_dl():
     parser.add_argument('-f', '--format_str', type=str, action='store',
                         help='Specify youtube-dl format string.',
                         default='bestaudio/best')
-    parser.add_argument('-k', '--keep_playlist_order', type=bool, default=False,
-                        action=argparse.BooleanOptionalAction,
+    parser.add_argument('-k', '--keep_playlist_order', default=False,
+                        action='store_true',
                         help='Whether to keep original playlist ordering or not.')
     parser.add_argument('-m', '--skip_mp3', action='store_true',
                         help='Don\'t convert downloaded songs to mp3')

--- a/spotify_dl/spotify_dl.py
+++ b/spotify_dl/spotify_dl.py
@@ -13,7 +13,7 @@ from spotify_dl.constants import VERSION
 from spotify_dl.models import db, Song
 from spotify_dl.scaffold import log, check_for_tokens
 from spotify_dl.spotify import fetch_tracks, parse_spotify_url, validate_spotify_url, get_item_name
-from spotify_dl.youtube import download_songs
+from spotify_dl.youtube import download_songs, default_filename, playlist_num_filename
 
 
 def spotify_dl():
@@ -84,7 +84,11 @@ def spotify_dl():
 
     songs = fetch_tracks(sp, item_type, args.url)
     if args.download is True:
-        download_songs(songs, save_path, args.format_str, args.skip_mp3, args.keep_playlist_order)
+        file_name_f = default_filename
+        if args.keep_playlist_order:
+            file_name_f = playlist_num_filename
+
+        download_songs(songs, save_path, args.format_str, args.skip_mp3, args.keep_playlist_order, file_name_f)
 
 
 if __name__ == '__main__':

--- a/spotify_dl/youtube.py
+++ b/spotify_dl/youtube.py
@@ -10,7 +10,16 @@ from spotify_dl.scaffold import log
 from spotify_dl.utils import sanitize
 
 
-def download_songs(songs, download_directory, format_string, skip_mp3, keep_playlist_order=False):
+def default_filename(song):
+    return sanitize(f"{song.get('artist')} - {song.get('name')}", '#')  # youtube-dl automatically replaces with #
+
+
+def playlist_num_filename(song):
+    return f"{song.get('playlist_num')} - {default_filename(song)}"
+
+
+def download_songs(songs, download_directory, format_string, skip_mp3,
+                   keep_playlist_order=False, file_name_f=default_filename):
     """
     Downloads songs from the YouTube URL passed to either current directory or download_directory, is it is passed.
     :param songs: Dictionary of songs and associated artist
@@ -18,16 +27,14 @@ def download_songs(songs, download_directory, format_string, skip_mp3, keep_play
     :param format_string: format string for the file conversion
     :param skip_mp3: Whether to skip conversion to MP3
     :param keep_playlist_order: Whether to keep original playlist ordering. Also, prefixes songs files with playlist num
+    :param file_name_f: optional func(song) -> str that returns a filename for the download (without extension)
     """
     log.debug(f"Downloading to {download_directory}")
     for song in songs:
         query = f"{song.get('artist')} - {song.get('name')} Lyrics".replace(":", "").replace("\"", "")
         download_archive = path.join(download_directory, 'downloaded_songs.txt')
 
-        file_name = sanitize(f"{song.get('artist')} - {song.get('name')}", '#')  # youtube-dl automatically replaces with #
-        if keep_playlist_order:
-            # add song number prefix
-            file_name = f"{song.get('playlist_num')} - {file_name}"
+        file_name = file_name_f(song)
         file_path = path.join(download_directory, file_name)
 
         outtmpl = f"{file_path}.%(ext)s"

--- a/tests/test_spotify_fetch_tracks.py
+++ b/tests/test_spotify_fetch_tracks.py
@@ -21,7 +21,8 @@ def test_spotify_playlist_fetch_one():
              'num': 6,
              'num_tracks': 15,
              'year': '1994',
-             'playlist_num': 1} == songs[0]
+             'playlist_num': 1,
+             'spotify_id': '2GpBrAoCwt48fxjgjlzMd4'} == songs[0]
 
     
 def test_spotify_playlist_fetch_more():
@@ -38,7 +39,8 @@ def test_spotify_playlist_fetch_more():
               'num': 10,
               'num_tracks': 20,
               'year': '2012',
-              'playlist_num': 1},
+              'playlist_num': 1,
+              'spotify_id': '4rzfv0JLZfVhOhbSQ8o5jZ'},
              {'album': 'Wellness & Dreaming Source',
               'artist': 'Vlasta Marek',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273aa2ff29970d9a63a49dfaeb2',
@@ -47,7 +49,8 @@ def test_spotify_playlist_fetch_more():
               'num': 21,
               'num_tracks': 25,
               'year': '2015',
-              'playlist_num': 2},
+              'playlist_num': 2,
+              'spotify_id': '5o3jMYOSbaVz3tkgwhELSV'},
              {'album': 'This Is Happening',
               'artist': 'LCD Soundsystem',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273ee0d0dce888c6c8a70db6e8b',
@@ -56,7 +59,8 @@ def test_spotify_playlist_fetch_more():
               'num': 4,
               'num_tracks': 9,
               'year': '2010',
-              'playlist_num': 3},
+              'playlist_num': 3,
+              'spotify_id': '4Cy0NHJ8Gh0xMdwyM9RkQm'},
              {'album': 'Glenn Horiuchi Trio / Gelenn Horiuchi Quartet: Mercy / Jump Start '
                        '/ Endpoints / Curl Out / Earthworks / Mind Probe / Null Set / '
                        'Another Space (A)',
@@ -67,7 +71,8 @@ def test_spotify_playlist_fetch_more():
               'num': 2,
               'num_tracks': 8,
               'year': '2011',
-              'playlist_num': 4},
+              'playlist_num': 4,
+              'spotify_id': '6hvFrZNocdt2FcKGCSY5NI'},
              {'album': 'All The Best (Spanish Version)',
               'artist': 'Zucchero',
               'cover': 'https://i.scdn.co/image/ab67616d0000b27304e57d181ff062f8339d6c71',
@@ -76,7 +81,8 @@ def test_spotify_playlist_fetch_more():
               'num': 18,
               'num_tracks': 18,
               'year': '2007',
-              'playlist_num': 5}] == songs
+              'playlist_num': 5,
+              'spotify_id': '2E2znCPaS8anQe21GLxcvJ'}] == songs
 
 
 def test_spotify_track_fetch_one():
@@ -92,7 +98,8 @@ def test_spotify_track_fetch_one():
              'num': 6,
              'num_tracks': 15,
              'year': '1994',
-             'playlist_num': 1} == songs[0]
+             'playlist_num': 1,
+             'spotify_id': '2GpBrAoCwt48fxjgjlzMd4'} == songs[0]
 
 
 def test_spotify_album_fetch_one():
@@ -108,7 +115,8 @@ def test_spotify_album_fetch_one():
              'num': 1,
              'num_tracks': 1,
              'year': '2012',
-             'playlist_num': 1} == songs[0]
+             'playlist_num': 1,
+             'spotify_id': '5EoKQDGE2zxrTfRFZF52u5'} == songs[0]
 
 
 def test_spotify_album_fetch_more():
@@ -124,7 +132,8 @@ def test_spotify_album_fetch_more():
               'num': 1,
               'num_tracks': 16,
               'year': '1974',
-              'playlist_num': 1},
+              'playlist_num': 1,
+              'spotify_id': '69Yw7H4bRIwfIxL0ZCZy8y'},
              {'album': 'Queen II (Deluxe Remastered Version)',
               'artist': 'Queen',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273dcf482c792ef848d7a994fd5',
@@ -133,7 +142,8 @@ def test_spotify_album_fetch_more():
               'num': 2,
               'num_tracks': 16,
               'year': '1974',
-              'playlist_num': 2},
+              'playlist_num': 2,
+              'spotify_id': '5GGSjXZeTgX9sKYBtl8K6U'},
              {'album': 'Queen II (Deluxe Remastered Version)',
               'artist': 'Queen',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273dcf482c792ef848d7a994fd5',
@@ -142,7 +152,8 @@ def test_spotify_album_fetch_more():
               'num': 3,
               'num_tracks': 16,
               'year': '1974',
-              'playlist_num': 3},
+              'playlist_num': 3,
+              'spotify_id': '0Ssh20fuVhmasLRJ97MLnp'},
              {'album': 'Queen II (Deluxe Remastered Version)',
               'artist': 'Queen',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273dcf482c792ef848d7a994fd5',
@@ -151,7 +162,8 @@ def test_spotify_album_fetch_more():
               'num': 4,
               'num_tracks': 16,
               'year': '1974',
-              'playlist_num': 4},
+              'playlist_num': 4,
+              'spotify_id': '2LasW39KJDE4VH9hTVNpE2'},
              {'album': 'Queen II (Deluxe Remastered Version)',
               'artist': 'Queen',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273dcf482c792ef848d7a994fd5',
@@ -160,7 +172,8 @@ def test_spotify_album_fetch_more():
               'num': 5,
               'num_tracks': 16,
               'year': '1974',
-              'playlist_num': 5},
+              'playlist_num': 5,
+              'spotify_id': '6jXrIu3hWbmJziw34IHIwM'},
              {'album': 'Queen II (Deluxe Remastered Version)',
               'artist': 'Queen',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273dcf482c792ef848d7a994fd5',
@@ -169,7 +182,8 @@ def test_spotify_album_fetch_more():
               'num': 6,
               'num_tracks': 16,
               'year': '1974',
-              'playlist_num': 6},
+              'playlist_num': 6,
+              'spotify_id': '5dHmGuUeRgp5f93G69tox5'},
              {'album': 'Queen II (Deluxe Remastered Version)',
               'artist': 'Queen',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273dcf482c792ef848d7a994fd5',
@@ -178,7 +192,8 @@ def test_spotify_album_fetch_more():
               'num': 7,
               'num_tracks': 16,
               'year': '1974',
-              'playlist_num': 7},
+              'playlist_num': 7,
+              'spotify_id': '2KPj0oB7cUuHQ3FuardOII'},
              {'album': 'Queen II (Deluxe Remastered Version)',
               'artist': 'Queen',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273dcf482c792ef848d7a994fd5',
@@ -187,7 +202,8 @@ def test_spotify_album_fetch_more():
               'num': 8,
               'num_tracks': 16,
               'year': '1974',
-              'playlist_num': 8},
+              'playlist_num': 8,
+              'spotify_id': '34CcBjL9WqEAtnl2i6Hbxa'},
              {'album': 'Queen II (Deluxe Remastered Version)',
               'artist': 'Queen',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273dcf482c792ef848d7a994fd5',
@@ -196,7 +212,8 @@ def test_spotify_album_fetch_more():
               'num': 9,
               'num_tracks': 16,
               'year': '1974',
-              'playlist_num': 9},
+              'playlist_num': 9,
+              'spotify_id': '1x9ak6LGIazLhfuaSIEkhG'},
              {'album': 'Queen II (Deluxe Remastered Version)',
               'artist': 'Queen',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273dcf482c792ef848d7a994fd5',
@@ -205,7 +222,8 @@ def test_spotify_album_fetch_more():
               'num': 10,
               'num_tracks': 16,
               'year': '1974',
-              'playlist_num': 10},
+              'playlist_num': 10,
+              'spotify_id': '4CITL18Tos0PscW1amCK4j'},
              {'album': 'Queen II (Deluxe Remastered Version)',
               'artist': 'Queen',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273dcf482c792ef848d7a994fd5',
@@ -214,7 +232,8 @@ def test_spotify_album_fetch_more():
               'num': 11,
               'num_tracks': 16,
               'year': '1974',
-              'playlist_num': 11},
+              'playlist_num': 11,
+              'spotify_id': '1e9Tt3nKBwRbuaU79kN3dn'},
              {'album': 'Queen II (Deluxe Remastered Version)',
               'artist': 'Queen',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273dcf482c792ef848d7a994fd5',
@@ -224,7 +243,8 @@ def test_spotify_album_fetch_more():
               'num': 1,
               'num_tracks': 16,
               'year': '1974',
-              'playlist_num': 12},
+              'playlist_num': 12,
+              'spotify_id': '0uHqoDT7J2TYBsJx6m4Tvi'},
              {'album': 'Queen II (Deluxe Remastered Version)',
               'artist': 'Queen',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273dcf482c792ef848d7a994fd5',
@@ -234,7 +254,8 @@ def test_spotify_album_fetch_more():
               'num': 2,
               'num_tracks': 16,
               'year': '1974',
-              'playlist_num': 13},
+              'playlist_num': 13,
+              'spotify_id': '3MIueGYoNiyBNfi5ukDgAK'},
              {'album': 'Queen II (Deluxe Remastered Version)',
               'artist': 'Queen',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273dcf482c792ef848d7a994fd5',
@@ -243,7 +264,8 @@ def test_spotify_album_fetch_more():
               'num': 3,
               'num_tracks': 16,
               'year': '1974',
-              'playlist_num': 14},
+              'playlist_num': 14,
+              'spotify_id': '34WAOFWdJ83a3YYrDAZTjm'},
              {'album': 'Queen II (Deluxe Remastered Version)',
               'artist': 'Queen',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273dcf482c792ef848d7a994fd5',
@@ -252,7 +274,8 @@ def test_spotify_album_fetch_more():
               'num': 4,
               'num_tracks': 16,
               'year': '1974',
-              'playlist_num': 15},
+              'playlist_num': 15,
+              'spotify_id': '2AFIPUlApcUwGEgOSDwoBz'},
              {'album': 'Queen II (Deluxe Remastered Version)',
               'artist': 'Queen',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273dcf482c792ef848d7a994fd5',
@@ -261,5 +284,6 @@ def test_spotify_album_fetch_more():
               'num': 5,
               'num_tracks': 16,
               'year': '1974',
-              'playlist_num': 16}] == songs
+              'playlist_num': 16,
+              'spotify_id': '4G4Sf18XkFvNTV5vAxiQyd'}] == songs
     assert (len(songs)) == 16

--- a/tests/test_spotify_fetch_tracks.py
+++ b/tests/test_spotify_fetch_tracks.py
@@ -20,7 +20,8 @@ def test_spotify_playlist_fetch_one():
              'name': 'Hotel California - Live On MTV, 1994',
              'num': 6,
              'num_tracks': 15,
-             'year': '1994'} == songs[0]
+             'year': '1994',
+             'playlist_num': 1} == songs[0]
 
     
 def test_spotify_playlist_fetch_more():
@@ -28,6 +29,7 @@ def test_spotify_playlist_fetch_more():
     url = "https://open.spotify.com/playlist/3cEYpjA9oz9GiPac4AsH4n"
     item_type = "playlist"
     songs = fetch_tracks(sp, item_type, url)
+    print(songs)
     assert [{'album': 'Progressive Psy Trance Picks Vol.8',
               'artist': 'Odiseo',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273ce6d0eef0c1ce77e5f95bbbc',
@@ -35,7 +37,8 @@ def test_spotify_playlist_fetch_more():
               'name': 'Api',
               'num': 10,
               'num_tracks': 20,
-              'year': '2012'},
+              'year': '2012',
+              'playlist_num': 1},
              {'album': 'Wellness & Dreaming Source',
               'artist': 'Vlasta Marek',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273aa2ff29970d9a63a49dfaeb2',
@@ -43,7 +46,8 @@ def test_spotify_playlist_fetch_more():
               'name': 'Is',
               'num': 21,
               'num_tracks': 25,
-              'year': '2015'},
+              'year': '2015',
+              'playlist_num': 2},
              {'album': 'This Is Happening',
               'artist': 'LCD Soundsystem',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273ee0d0dce888c6c8a70db6e8b',
@@ -51,7 +55,8 @@ def test_spotify_playlist_fetch_more():
               'name': 'All I Want',
               'num': 4,
               'num_tracks': 9,
-              'year': '2010'},
+              'year': '2010',
+              'playlist_num': 3},
              {'album': 'Glenn Horiuchi Trio / Gelenn Horiuchi Quartet: Mercy / Jump Start '
                        '/ Endpoints / Curl Out / Earthworks / Mind Probe / Null Set / '
                        'Another Space (A)',
@@ -61,7 +66,8 @@ def test_spotify_playlist_fetch_more():
               'name': 'Endpoints',
               'num': 2,
               'num_tracks': 8,
-              'year': '2011'},
+              'year': '2011',
+              'playlist_num': 4},
              {'album': 'All The Best (Spanish Version)',
               'artist': 'Zucchero',
               'cover': 'https://i.scdn.co/image/ab67616d0000b27304e57d181ff062f8339d6c71',
@@ -69,7 +75,8 @@ def test_spotify_playlist_fetch_more():
               'name': 'You Are So Beautiful',
               'num': 18,
               'num_tracks': 18,
-              'year': '2007'}] == songs
+              'year': '2007',
+              'playlist_num': 5}] == songs
 
 
 def test_spotify_track_fetch_one():
@@ -84,7 +91,8 @@ def test_spotify_track_fetch_one():
              'name': 'Hotel California - Live On MTV, 1994',
              'num': 6,
              'num_tracks': 15,
-             'year': '1994'} == songs[0]
+             'year': '1994',
+             'playlist_num': 1} == songs[0]
 
 
 def test_spotify_album_fetch_one():
@@ -99,7 +107,8 @@ def test_spotify_album_fetch_one():
              'name': 'Simple Song',
              'num': 1,
              'num_tracks': 1,
-             'year': '2012'} == songs[0]
+             'year': '2012',
+             'playlist_num': 1} == songs[0]
 
 
 def test_spotify_album_fetch_more():
@@ -114,7 +123,8 @@ def test_spotify_album_fetch_more():
               'name': 'Procession - Remastered 2011',
               'num': 1,
               'num_tracks': 16,
-              'year': '1974'},
+              'year': '1974',
+              'playlist_num': 1},
              {'album': 'Queen II (Deluxe Remastered Version)',
               'artist': 'Queen',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273dcf482c792ef848d7a994fd5',
@@ -122,7 +132,8 @@ def test_spotify_album_fetch_more():
               'name': 'Father To Son - Remastered 2011',
               'num': 2,
               'num_tracks': 16,
-              'year': '1974'},
+              'year': '1974',
+              'playlist_num': 2},
              {'album': 'Queen II (Deluxe Remastered Version)',
               'artist': 'Queen',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273dcf482c792ef848d7a994fd5',
@@ -130,7 +141,8 @@ def test_spotify_album_fetch_more():
               'name': 'White Queen (As It Began) - Remastered 2011',
               'num': 3,
               'num_tracks': 16,
-              'year': '1974'},
+              'year': '1974',
+              'playlist_num': 3},
              {'album': 'Queen II (Deluxe Remastered Version)',
               'artist': 'Queen',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273dcf482c792ef848d7a994fd5',
@@ -138,7 +150,8 @@ def test_spotify_album_fetch_more():
               'name': 'Some Day One Day - Remastered 2011',
               'num': 4,
               'num_tracks': 16,
-              'year': '1974'},
+              'year': '1974',
+              'playlist_num': 4},
              {'album': 'Queen II (Deluxe Remastered Version)',
               'artist': 'Queen',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273dcf482c792ef848d7a994fd5',
@@ -146,7 +159,8 @@ def test_spotify_album_fetch_more():
               'name': 'The Loser In The End - Remastered 2011',
               'num': 5,
               'num_tracks': 16,
-              'year': '1974'},
+              'year': '1974',
+              'playlist_num': 5},
              {'album': 'Queen II (Deluxe Remastered Version)',
               'artist': 'Queen',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273dcf482c792ef848d7a994fd5',
@@ -154,7 +168,8 @@ def test_spotify_album_fetch_more():
               'name': 'Ogre Battle - Remastered 2011',
               'num': 6,
               'num_tracks': 16,
-              'year': '1974'},
+              'year': '1974',
+              'playlist_num': 6},
              {'album': 'Queen II (Deluxe Remastered Version)',
               'artist': 'Queen',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273dcf482c792ef848d7a994fd5',
@@ -162,7 +177,8 @@ def test_spotify_album_fetch_more():
               'name': "The Fairy Feller's Master-Stroke - Remastered 2011",
               'num': 7,
               'num_tracks': 16,
-              'year': '1974'},
+              'year': '1974',
+              'playlist_num': 7},
              {'album': 'Queen II (Deluxe Remastered Version)',
               'artist': 'Queen',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273dcf482c792ef848d7a994fd5',
@@ -170,7 +186,8 @@ def test_spotify_album_fetch_more():
               'name': 'Nevermore - Remastered 2011',
               'num': 8,
               'num_tracks': 16,
-              'year': '1974'},
+              'year': '1974',
+              'playlist_num': 8},
              {'album': 'Queen II (Deluxe Remastered Version)',
               'artist': 'Queen',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273dcf482c792ef848d7a994fd5',
@@ -178,7 +195,8 @@ def test_spotify_album_fetch_more():
               'name': 'The March Of The Black Queen - Remastered 2011',
               'num': 9,
               'num_tracks': 16,
-              'year': '1974'},
+              'year': '1974',
+              'playlist_num': 9},
              {'album': 'Queen II (Deluxe Remastered Version)',
               'artist': 'Queen',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273dcf482c792ef848d7a994fd5',
@@ -186,7 +204,8 @@ def test_spotify_album_fetch_more():
               'name': 'Funny How Love Is - Remastered 2011',
               'num': 10,
               'num_tracks': 16,
-              'year': '1974'},
+              'year': '1974',
+              'playlist_num': 10},
              {'album': 'Queen II (Deluxe Remastered Version)',
               'artist': 'Queen',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273dcf482c792ef848d7a994fd5',
@@ -194,7 +213,8 @@ def test_spotify_album_fetch_more():
               'name': 'Seven Seas Of Rhye - Remastered 2011',
               'num': 11,
               'num_tracks': 16,
-              'year': '1974'},
+              'year': '1974',
+              'playlist_num': 11},
              {'album': 'Queen II (Deluxe Remastered Version)',
               'artist': 'Queen',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273dcf482c792ef848d7a994fd5',
@@ -203,7 +223,8 @@ def test_spotify_album_fetch_more():
                       '2011 Remix',
               'num': 1,
               'num_tracks': 16,
-              'year': '1974'},
+              'year': '1974',
+              'playlist_num': 12},
              {'album': 'Queen II (Deluxe Remastered Version)',
               'artist': 'Queen',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273dcf482c792ef848d7a994fd5',
@@ -212,7 +233,8 @@ def test_spotify_album_fetch_more():
                       'December 1975',
               'num': 2,
               'num_tracks': 16,
-              'year': '1974'},
+              'year': '1974',
+              'playlist_num': 13},
              {'album': 'Queen II (Deluxe Remastered Version)',
               'artist': 'Queen',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273dcf482c792ef848d7a994fd5',
@@ -220,7 +242,8 @@ def test_spotify_album_fetch_more():
               'name': 'Seven Seas Of Rhye - Instrumental Mix 2011',
               'num': 3,
               'num_tracks': 16,
-              'year': '1974'},
+              'year': '1974',
+              'playlist_num': 14},
              {'album': 'Queen II (Deluxe Remastered Version)',
               'artist': 'Queen',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273dcf482c792ef848d7a994fd5',
@@ -228,7 +251,8 @@ def test_spotify_album_fetch_more():
               'name': 'Nevermore - Live BBC Session, London / April 1974',
               'num': 4,
               'num_tracks': 16,
-              'year': '1974'},
+              'year': '1974',
+              'playlist_num': 15},
              {'album': 'Queen II (Deluxe Remastered Version)',
               'artist': 'Queen',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273dcf482c792ef848d7a994fd5',
@@ -236,5 +260,6 @@ def test_spotify_album_fetch_more():
               'name': 'See What A Fool I’ve Been - B-Side Version / Remastered 2011',
               'num': 5,
               'num_tracks': 16,
-              'year': '1974'}] == songs
+              'year': '1974',
+              'playlist_num': 16}] == songs
     assert (len(songs)) == 16

--- a/tests/test_spotify_fetch_tracks.py
+++ b/tests/test_spotify_fetch_tracks.py
@@ -30,7 +30,6 @@ def test_spotify_playlist_fetch_more():
     url = "https://open.spotify.com/playlist/3cEYpjA9oz9GiPac4AsH4n"
     item_type = "playlist"
     songs = fetch_tracks(sp, item_type, url)
-    print(songs)
     assert [{'album': 'Progressive Psy Trance Picks Vol.8',
               'artist': 'Odiseo',
               'cover': 'https://i.scdn.co/image/ab67616d0000b273ce6d0eef0c1ce77e5f95bbbc',


### PR DESCRIPTION
Hey,

I'm using the library in one of my projects and for my integration I needed to be able to control the output filename (something else than `f"{song.get('artist')} - {song.get('name')}"`). This PR allows to pass the naming function dynamically. Since my project relies on a unique ID I'll also expose a new key `spotify_id` in the `song` dict so I can use this unique parameter in my naming.

Other things "fixed" in this PR:
- fixed tests: "playlist_num" was missing
- fix: replaced action argparse.BooleanOptionalAction with 'store_true'  (keep_playlist_order), because that's only Python 3.9

Note: This PR **does not** break any existing interfaces.