### PR TITLE
Continue to download the playlist if missing files

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -31,5 +31,4 @@ jobs:
         SPOTIPY_CLIENT_ID:  ${{ secrets.SPOTIPY_CLIENT_ID }}
         SPOTIPY_CLIENT_SECRET:  ${{ secrets.SPOTIPY_CLIENT_SECRET }}
       run: |
-        pip install pytest pytest-cov
-        pytest --cov=spotify_dl tests/
+        make tests

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -31,4 +31,5 @@ jobs:
         SPOTIPY_CLIENT_ID:  ${{ secrets.SPOTIPY_CLIENT_ID }}
         SPOTIPY_CLIENT_SECRET:  ${{ secrets.SPOTIPY_CLIENT_SECRET }}
       run: |
+        sudo apt-get install ffmpeg
         make tests

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
-.PHONY: tests
+.PHONY: tests clean
+default: tests
 
-tests:
+clean:
+	find . | grep -E "\(__pycache__|\.pyc|\.pyo$\)" | xargs rm -rf
+
+tests: clean
 	pip install -e .
 	pip install pytest pytest-cov
 	pytest --cov=spotify_dl tests/

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ default: tests
 
 clean:
 	find . | grep -E "\(__pycache__|\.pyc|\.pyo$\)" | xargs rm -rf
+	rm -f tests/*mp3
+	rm -f tests/downloaded_songs.txt
 
 tests: clean
 	pip install -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 peewee==3.13.3
 sentry_sdk==0.19.4
-youtube-dl>=2021.1.24.1
+youtube-dl>=2021.04.01
 spotipy==2.16.1
 mutagen==1.45.1
 spotipy== 2.16.1

--- a/spotify_dl/youtube.py
+++ b/spotify_dl/youtube.py
@@ -65,7 +65,12 @@ def download_songs(songs, download_directory, format_string, skip_mp3,
                 continue
 
         if not skip_mp3:
-            song_file = MP3(path.join(f"{file_path}.mp3"), ID3=EasyID3)
+            try:
+                song_file = MP3(path.join(f"{file_path}.mp3"), ID3=EasyID3)
+            except Exception as e:
+                log.debug(e)
+                print('Failed to download: {}, please ensure YouTubeDL is up-to-date. '.format(query))
+                continue
             song_file['date'] = song.get('year')
             if keep_playlist_order:
                 song_file['tracknumber'] = str(song.get('playlist_num'))

--- a/spotify_dl/youtube.py
+++ b/spotify_dl/youtube.py
@@ -1,6 +1,7 @@
 import urllib.request
 from os import path
 
+import mutagen
 import youtube_dl
 from mutagen.easyid3 import EasyID3
 from mutagen.id3 import APIC, ID3
@@ -67,7 +68,7 @@ def download_songs(songs, download_directory, format_string, skip_mp3,
         if not skip_mp3:
             try:
                 song_file = MP3(path.join(f"{file_path}.mp3"), ID3=EasyID3)
-            except Exception as e:
+            except mutagen.MutagenError as e:
                 log.debug(e)
                 print('Failed to download: {}, please ensure YouTubeDL is up-to-date. '.format(query))
                 continue

--- a/tests/test_spotify_fetch_tracks.py
+++ b/tests/test_spotify_fetch_tracks.py
@@ -1,10 +1,12 @@
 from spotipy.oauth2 import SpotifyClientCredentials
 from spotify_dl.spotify import fetch_tracks
 import spotipy
-
+import base64
 
 def spotify_auth():
-    client = spotipy.Spotify(auth_manager=SpotifyClientCredentials())
+    # test client ids, b64 for just to deter. 
+    client = spotipy.Spotify(auth_manager=SpotifyClientCredentials(client_id=base64.b64decode('NjliZDE4ZjNiNDY3NGMyNTkwNTllMzE5YTQ1ZGQwMzY=').decode('ascii'),
+                                                                    client_secret=base64.b64decode('NTczY2UwYmM2OWUzNDdkNzg3NjgwZDBlMzJmOTQ3MGM=').decode('ascii')))
     return client
 
 


### PR DESCRIPTION
Just a patch for the missing file's recurrent issue. It seems that for some reason, youtube_dl does not find some videos but does not throw an exception.