### PR TITLE
Fix local files causing error

### DIFF
--- a/spotify_dl/spotify.py
+++ b/spotify_dl/spotify.py
@@ -44,9 +44,12 @@ def fetch_tracks(sp, item_type, url):
                     cover = item['track']['album']['images'][0]['url']
                 else:
                     cover = None
-            
-                if len(sp.artist(artist_id=item['track']['artists'][0]['uri'])['genres']) > 0:
-                    genre = sp.artist(artist_id=item['track']['artists'][0]['uri'])['genres'][0]
+
+                artists = track_info.get('artists')
+                main_artist_id = artists[0].get('uri', None) if len(artists) > 0 else None
+                genres = sp.artist(artist_id=main_artist_id).get('genres', []) if main_artist_id else []
+                if len(genres) > 0:
+                    genre = genres[0]
                 else:
                     genre = ""
                 songs_list.append({"name": track_name, "artist": track_artist, "album": track_album, "year": track_year,

--- a/tests/test_spotify_fetch_tracks.py
+++ b/tests/test_spotify_fetch_tracks.py
@@ -288,3 +288,19 @@ def test_spotify_album_fetch_more():
               'playlist_num': 16,
               'spotify_id': '4G4Sf18XkFvNTV5vAxiQyd'}] == songs
     assert (len(songs)) == 16
+
+def test_spotify_playlist_fetch_local_file():
+    sp = spotify_auth()
+    url = "https://open.spotify.com/playlist/1TWZ36xJ8qkvSeAQQUvU5b?si=ad56b6bb085b4ab9"
+    item_type = "playlist"
+    songs = fetch_tracks(sp, item_type, url)
+    assert [{'album': "Yoshi's Island",
+             'artist': 'Koji Kondo',
+             'cover': None,
+             'genre': '',
+             'name': 'Flower Garden',
+             'num': 0,
+             'num_tracks': None,
+             'year': '',
+             'playlist_num': 1,
+             'spotify_id': None}] == songs


### PR DESCRIPTION
Seems like #181 fixes the TypeError that was originally reported in #167, but it didn't solve the fact that local files still caused an error. Upon further inspection, since an artist from a local file had a uri of `None`, and that was being passed into `sp.artist`, that was still causing an error. Additionally, it could be possible that there are no artists associated, which would cause an IndexError.

I added checks to ensure
- There is at least one artist before trying to get their uri
- The artist had a non-None uri before passing it into `sp.artist`

Also, added a test for the local files case. It doesn't cover the case where the artist though. Additionally, I'm sourcing the playlist from one I created, which I could forget about and delete in the future, so I recommend creating your own playlist with songs from local files with an artist, and without an artist and replacing it in the test.

fixes #167 