### PR TITLE
Fix TypeError when fetching a playlist with a podcast or similar item

### DIFF
--- a/spotify_dl/spotify.py
+++ b/spotify_dl/spotify.py
@@ -27,7 +27,15 @@ def fetch_tracks(sp, item_type, url):
                                       additional_types=['track'], offset=offset)
             total_songs = items.get('total')
             for item in items['items']:
+                
                 track_info = item.get('track')
+                
+                # If the user has a podcast in their playlist, there will be no track
+                # Without this conditional, the program will fail later on when the metadata is fetched
+                if track_info == None:
+                    offset += 1
+                    continue
+                
                 track_album_info = track_info.get('album')
                 
                 track_num = track_info.get('track_number')


### PR DESCRIPTION
If the user has a podcast in their playlist, which Spotify supports, the download will fail as metadata such as `album_name` can't be fetched for podcasts.

This fixes that issue by skipping all items that do not have a `track`.

Note: Many Spotify users use podcasts in order to listen to remixes or edited songs that are not officially on Spotify - therefore, it could be within the scope of this program to download them as well. I could not find a way of doing this that integrated with the current structure of the program, but it might be worth looking into.