### PR TITLE
fix: bug risk informed by deepsource.io

### DIFF
--- a/spotify_dl/spotify_dl.py
+++ b/spotify_dl/spotify_dl.py
@@ -43,7 +43,7 @@ def spotify_dl():
 
     if args.version:
         print("spotify_dl v{}".format(VERSION))
-        exit(0)
+        sys.exit(0)
 
     db.connect()
     db.create_tables([Song])
@@ -64,7 +64,7 @@ def spotify_dl():
     log.debug('Setting debug mode on spotify_dl')
 
     if not check_for_tokens():
-        exit(1)
+        sys.exit(1)
 
     sp = spotipy.Spotify(auth_manager=SpotifyClientCredentials())
     log.debug('Arguments: {}'.format(args))


### PR DESCRIPTION
https://deepsource.io/gh/SathyaBhat/spotify-dl/issue/PYL-R1722/occurrences?page=1

The exit or quit functions don't exist at top-level if python is started with the -S flag, and will raise an error. Use sys.exit() instead.

The exit and quit functions are actually site.Quitter objects and are loaded, at interpreter start up, from site.py. However, if the interpreter is started with the -S flag, or a custom site.py is used then exit and quit may not be present. It is recommended to use sys.exit() which is built into the interpreter and is guaranteed to be present.