### PR TITLE
Use XDG Base Directory specification

### DIFF
--- a/spotify_dl/constants.py
+++ b/spotify_dl/constants.py
@@ -1,4 +1,10 @@
+import os
+
 __all__ = ['VERSION']
 
 VERSION = '7.6.0'
-SAVE_PATH = '~/.spotifydl'
+
+if os.getenv("XDG_CACHE_HOME") is not None:
+    SAVE_PATH = os.getenv("XDG_CACHE_HOME") + "/spotifydl"
+else:
+    SAVE_PATH = os.getenv("HOME") + ".cache/spotifydl"


### PR DESCRIPTION
I think the best idea is to store non-essential files (that can be deleted without harm) in XDG_CACHE_HOME, as required by the [XDG Base Directory specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).

For systems that do not have this environment variable by default (e.g. macOS), can use $HOME/.cache.

This will help reduce the number of directories in the user's home directory.