### PR TITLE
Add Python 3.9 and 3.10 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,8 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Internet',
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: Libraries :: Python Modules',


### PR DESCRIPTION
`spotify_dl` appears to be stable for Python 3.9 and 3.10. So let's add mentions of these versions.
