### PR TITLE
Accept a wider range of versions in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-sentry_sdk==1.5.3
+sentry_sdk>=1.5,<2
 yt-dlp>=2022.01.21
-spotipy==2.16.1
-mutagen==1.45.1
-rich==11.0.0
+spotipy>=2.16,<3
+mutagen>=1.45,<2
+rich>=11.0,<12


### PR DESCRIPTION
The current dependencies are pinned to a specific patch, which is often too restrictive for those installing the software without pip (mainly linux users).
This change allows to use any version of the dependency, from the current minor up to the next breaking change (the following major).
This ensures that all the features currently in use are available, while allowing users to update their systems when new compatible versions are released.