### PR TITLE
Use the tokens found during check

### DIFF
--- a/spotify_dl/scaffold.py
+++ b/spotify_dl/scaffold.py
@@ -4,7 +4,7 @@ import sentry_sdk
 from rich.logging import RichHandler
 from rich.console import Console
 
-__all__ = ['log', 'check_for_tokens', 'console']
+__all__ = ['log', 'get_tokens', 'console']
 
 logging.basicConfig(level=logging.INFO,
                     format="%(message)s",
@@ -15,7 +15,7 @@ log = logging.getLogger('sdl')
 sentry_sdk.init("https://fc66a23d79634b9bba1690ea13e289f0@o321064.ingest.sentry.io/2383261")
 
 
-def check_for_tokens():
+def get_tokens():
     """
     Checks if the required API keys for Spotify has been set.
     :param name: Name to be cleaned up
@@ -45,5 +45,5 @@ def check_for_tokens():
             Get your credentials at
                 https://developer.spotify.com/my-applications
         ''')
-        return False
-    return True
+        return None
+    return CLIENT_ID, CLIENT_SECRET

--- a/spotify_dl/spotify_dl.py
+++ b/spotify_dl/spotify_dl.py
@@ -9,7 +9,7 @@ import spotipy
 from spotipy.oauth2 import SpotifyClientCredentials
 
 from spotify_dl.constants import VERSION
-from spotify_dl.scaffold import log, check_for_tokens, console
+from spotify_dl.scaffold import log, get_tokens, console
 from spotify_dl.spotify import fetch_tracks, parse_spotify_url, validate_spotify_url, get_item_name
 from spotify_dl.youtube import download_songs, default_filename, playlist_num_filename
 
@@ -65,10 +65,12 @@ def spotify_dl():
     console.log(f"Starting spotify_dl [bold green]v{VERSION}[/bold green]")
     log.debug('Setting debug mode on spotify_dl')
 
-    if not check_for_tokens():
+    tokens = get_tokens()
+    if tokens is None:
         sys.exit(1)
 
-    sp = spotipy.Spotify(auth_manager=SpotifyClientCredentials())
+    C_ID, C_SECRET = tokens
+    sp = spotipy.Spotify(auth_manager=SpotifyClientCredentials(client_id=C_ID,client_secret=C_SECRET))
     log.debug('Arguments: {}'.format(args))
 
     for url in args.url:


### PR DESCRIPTION
Instead of only checking for the envvars, this change stores the result and uses the credentials when calling spotipy. Right now we are relying on the fact that spotipy should read those same variables, but it may no longer be the case in the future.

This change avoids the risk of the variables changing between the check and their use, also making the log at [spotify_dl/scaffold.py#L27](https://github.com/SathyaBhat/spotify-dl/blob/master/spotify_dl/scaffold.py#L27) more meaningful, since we now know those were the ones actually used.