### PR TITLE
Allow for more dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-sentry_sdk~=1.5.0
+sentry_sdk~=1.5
 yt-dlp>=2022.01.21
-spotipy~=2.19.0
-mutagen~=1.45.0
-rich~=12.0.0
+spotipy~=2.19
+mutagen~=1.45
+rich~=12.0


### PR DESCRIPTION
The changes introduced in #265 made the dependencies once again too restrictive. For the same reasons expressed in #242, I suggest allowing all versions up to the following major release.

As an example, `rich~=12.0.0` means `rich>=12.0.0, ==12.0.*`, but this puts it already outside the versions available in the Gentoo tree ([here](https://packages.gentoo.org/packages/dev-python/rich) you can see the oldest is 12.2.0).