### PR TITLE
Download music from alternate YouTube URL

### DIFF
--- a/spotify_dl/spotify_dl.py
+++ b/spotify_dl/spotify_dl.py
@@ -23,6 +23,13 @@ def spotify_dl():
                         help='Specify download directory.', required=False, default = ".")
     parser.add_argument('-d', '--download', action='store_true',
                         help='Download using youtube-dl', default=True)
+    
+    """Newly added argument (by kinglobster). Specifies an alternative youtube url in case that the one
+    determined by the program is mistaken or does not fulfill the requirements of quality or any other."""
+    parser.add_argument('-y', '--alternative_yt_url', action='store', type=str, required=False,
+                        help='Specify youtube url to download the song from. The metadata form spotify'
+                             'and the audio from youtube will still merge in a single file.')
+    
     parser.add_argument('-f', '--format_str', type=str, action='store',
                         help='Specify youtube-dl format string.',
                         default='bestaudio/best')
@@ -99,8 +106,18 @@ def spotify_dl():
             if args.keep_playlist_order:
                 file_name_f = playlist_num_filename
             if save_path is not None:
-                download_songs(songs, save_path, args.format_str, args.skip_mp3, args.keep_playlist_order, args.no_overwrites, args.skip_non_music_sections, file_name_f)
+                #download_songs(songs, save_path, args.format_str, args.skip_mp3, args.keep_playlist_order, args.no_overwrites, args.skip_non_music_sections, file_name_f)
+                # From this line downwards, modified code by kinglobster
 
+                if args.alternative_yt_url is not None:
+                    alternative_yt_url = args.alternative_yt_url
+                    download_songs(songs, save_path, args.format_str, args.skip_mp3, args.keep_playlist_order,
+                                   args.no_overwrites, args.skip_non_music_sections, file_name_f, alternative_yt_url)
+                else:
+                    download_songs(songs, save_path, args.format_str, args.skip_mp3, args.keep_playlist_order,
+                                   args.no_overwrites, args.skip_non_music_sections, file_name_f)
+
+                # End of modified code by kinglobster
 
 if __name__ == '__main__':
     spotify_dl()

--- a/spotify_dl/youtube.py
+++ b/spotify_dl/youtube.py
@@ -76,11 +76,20 @@ def download_songs(songs, download_directory, format_string, skip_mp3,
 
         with youtube_dl.YoutubeDL(ydl_opts) as ydl:
             try:
-                ydl.download([query])
-            except Exception as e:
-                log.debug(e)
-                print('Failed to download: {}, please ensure YouTubeDL is up-to-date. '.format(query))
-                continue
+                #ydl.download([query])
+                # From this line, modified code by kinglobster
+
+                if alternative_yt_url is None:
+                    ydl.download([query])
+                else:
+                    print('###### Downloading from alternative url!!!: ' + alternative_yt_url)
+                    ydl.download(alternative_yt_url)
+
+                # End of modified code            
+                except Exception as e:
+                    log.debug(e)
+                    print('Failed to download: {}, please ensure YouTubeDL is up-to-date. '.format(query))
+                    continue
 
         if not skip_mp3:
             mp3filename = f"{file_path}.mp3"

--- a/spotify_dl/youtube.py
+++ b/spotify_dl/youtube.py
@@ -85,11 +85,12 @@ def download_songs(songs, download_directory, format_string, skip_mp3,
                     print('###### Downloading from alternative url!!!: ' + alternative_yt_url)
                     ydl.download(alternative_yt_url)
 
-                # End of modified code            
-                except Exception as e:
-                    log.debug(e)
-                    print('Failed to download: {}, please ensure YouTubeDL is up-to-date. '.format(query))
-                    continue
+                # End of modified code       
+                
+            except Exception as e:
+                log.debug(e)
+                print('Failed to download: {}, please ensure YouTubeDL is up-to-date. '.format(query))
+                continue
 
         if not skip_mp3:
             mp3filename = f"{file_path}.mp3"


### PR DESCRIPTION
This new option provides a way to specify an alternate YouTube URL from which to download the music in case the one determined by the program does not fit the quality standards or is mistaken or for any other reason. 

While using this tool I found the option useful a number of times. The modifications are quite simple and I hope you find them useful too.