### PR TITLE
Added option to download through a proxy

### DIFF
--- a/spotify_dl/spotify_dl.py
+++ b/spotify_dl/spotify_dl.py
@@ -104,6 +104,15 @@ def spotify_dl():
         default=0,
         help="Use multiprocessing [-m [int:numcores]",
     )
+    parser.add_argument(
+        "-p",
+        "--proxy",
+        action="store",
+        type=str,
+        default="",
+        required=False,
+        help="Download through a proxy. Support HTTP & SOCKS5. Use 'http://username:password@hostname:port' or 'http://hostname:port'",
+    )
     args = parser.parse_args()
     num_cores = os.cpu_count()
     args.multi_core = int(args.multi_core)
@@ -183,6 +192,7 @@ def spotify_dl():
             skip_non_music_sections=args.skip_non_music_sections,
             file_name_f=file_name_f,
             multi_core=args.multi_core,
+            proxy=args.proxy,
         )
 
 

--- a/spotify_dl/spotify_dl.py
+++ b/spotify_dl/spotify_dl.py
@@ -110,7 +110,6 @@ def spotify_dl():
         action="store",
         type=str,
         default="",
-        required=False,
         help="Download through a proxy. Support HTTP & SOCKS5. Use 'http://username:password@hostname:port' or 'http://hostname:port'",
     )
     args = parser.parse_args()

--- a/spotify_dl/youtube.py
+++ b/spotify_dl/youtube.py
@@ -147,6 +147,7 @@ def find_and_download_songs(kwargs):
             file_path = path.join(kwargs["track_db"][i]["save_path"], file_name)
             outtmpl = f"{file_path}.%(ext)s"
             ydl_opts = {
+            	"proxy": kwargs["proxy"],
                 "default_search": "ytsearch",
                 "format": "bestaudio/best",
                 "outtmpl": outtmpl,

--- a/spotify_dl/youtube.py
+++ b/spotify_dl/youtube.py
@@ -147,7 +147,7 @@ def find_and_download_songs(kwargs):
             file_path = path.join(kwargs["track_db"][i]["save_path"], file_name)
             outtmpl = f"{file_path}.%(ext)s"
             ydl_opts = {
-            	"proxy": kwargs["proxy"],
+            	    "proxy": kwargs["proxy"],
                 "default_search": "ytsearch",
                 "format": "bestaudio/best",
                 "outtmpl": outtmpl,

--- a/spotify_dl/youtube.py
+++ b/spotify_dl/youtube.py
@@ -147,7 +147,7 @@ def find_and_download_songs(kwargs):
             file_path = path.join(kwargs["track_db"][i]["save_path"], file_name)
             outtmpl = f"{file_path}.%(ext)s"
             ydl_opts = {
-            	"proxy": kwargs["proxy"],
+                "proxy": kwargs["proxy"],
                 "default_search": "ytsearch",
                 "format": "bestaudio/best",
                 "outtmpl": outtmpl,

--- a/spotify_dl/youtube.py
+++ b/spotify_dl/youtube.py
@@ -147,7 +147,7 @@ def find_and_download_songs(kwargs):
             file_path = path.join(kwargs["track_db"][i]["save_path"], file_name)
             outtmpl = f"{file_path}.%(ext)s"
             ydl_opts = {
-            	    "proxy": kwargs["proxy"],
+            	"proxy": kwargs["proxy"],
                 "default_search": "ytsearch",
                 "format": "bestaudio/best",
                 "outtmpl": outtmpl,

--- a/spotify_dl/youtube.py
+++ b/spotify_dl/youtube.py
@@ -147,7 +147,7 @@ def find_and_download_songs(kwargs):
             file_path = path.join(kwargs["track_db"][i]["save_path"], file_name)
             outtmpl = f"{file_path}.%(ext)s"
             ydl_opts = {
-                "proxy": kwargs["proxy"],
+                "proxy": kwargs.get('proxy'),
                 "default_search": "ytsearch",
                 "format": "bestaudio/best",
                 "outtmpl": outtmpl,


### PR DESCRIPTION
In connection with the [issue](https://github.com/SathyaBhat/spotify-dl/issues/304) I created. I added the option to download through a proxy. 

It works with HTTP and SOCKS5 proxies.

For HTTP : spotify_dl -p "http://username:password@hostname:port" or "http://hostname:port"
For SOCKS5 : spotify_dl -p "socks5://username:password@hostname:port" or "socks5://hostname:port"

I hope this will help some people 🚀 



