### PR TITLE
skip sponsorblock by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ If you want to make use of parallel download, pass `-mc <number>`, where `<numbe
 
     spotify_dl -mc 4 -l spotify_playlist_link_1 spotify_playlist_link_2
 
+Spotify-dl can make use of SponsorBlock and skip non-music sections when downloading from YouTube. This is disabled by default and can be enabled using:
+
+        spotify_dl -l spotify_playlist_link_1 -s y
+
 For running in verbose mode, append `-V`
 
     spotify_dl -V -l spotify_playlist_link -o download_directory

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 sentry_sdk~=1.5
 yt-dlp>=2022.01.21
-spotipy~=2.19
+spotipy~=2.21
 mutagen~=1.45
 rich~=12.0
+urllib3~=1.26

--- a/spotify_dl/spotify_dl.py
+++ b/spotify_dl/spotify_dl.py
@@ -72,10 +72,10 @@ def spotify_dl():
     )
     parser.add_argument(
         "-s",
-        "--skip_non_music_sections",
-        default=False,
-        action="store_true",
-        help="Whether to skip non-music sections using SponsorBlock API.",
+        "--use_sponsorblock",
+        default="no",
+        action="store",
+        help="Whether to skip non-music sections using SponsorBlock API. Pass y or yes to skip using SponsorBlock",
     )
     parser.add_argument(
         "-w",
@@ -148,7 +148,9 @@ def spotify_dl():
         )
     )
     log.debug("Arguments: %s ", args)
-
+    console.print(
+        f"Sponsorblock enabled?: [bold green]{args.use_sponsorblock}[/bold green]"
+    )
     valid_urls = validate_spotify_urls(args.url)
     if not valid_urls:
         sys.exit(1)
@@ -180,7 +182,7 @@ def spotify_dl():
             skip_mp3=args.skip_mp3,
             keep_playlist_order=args.keep_playlist_order,
             no_overwrites=args.no_overwrites,
-            skip_non_music_sections=args.skip_non_music_sections,
+            use_sponsorblock=args.use_sponsorblock,
             file_name_f=file_name_f,
             multi_core=args.multi_core,
         )

--- a/spotify_dl/youtube.py
+++ b/spotify_dl/youtube.py
@@ -8,7 +8,7 @@ import yt_dlp
 from mutagen.easyid3 import EasyID3
 from mutagen.id3 import APIC, ID3
 from mutagen.mp3 import MP3
-from spotify_dl.scaffold import log, console
+from spotify_dl.scaffold import log
 from spotify_dl.utils import sanitize
 from spotify_dl.constants import DOWNLOAD_LIST
 

--- a/spotify_dl/youtube.py
+++ b/spotify_dl/youtube.py
@@ -8,7 +8,7 @@ import yt_dlp
 from mutagen.easyid3 import EasyID3
 from mutagen.id3 import APIC, ID3
 from mutagen.mp3 import MP3
-from spotify_dl.scaffold import log
+from spotify_dl.scaffold import log, console
 from spotify_dl.utils import sanitize
 from spotify_dl.constants import DOWNLOAD_LIST
 
@@ -123,6 +123,7 @@ def find_and_download_songs(kwargs):
     the youtube_search lib is used to search for songs and get best url
     :param kwargs: dictionary of key value arguments to be used in download
     """
+    sponsorblock_postprocessor = []
     reference_file = kwargs["reference_file"]
     with open(reference_file, "r", encoding="utf-8") as file:
         for line in file:
@@ -140,9 +141,20 @@ def find_and_download_songs(kwargs):
             file_name = kwargs["file_name_f"](
                 name=name, artist=artist, track_num=kwargs["track_db"][i].get("num")
             )
-            sponsorblock_remove_list = (
-                ["music_offtopic"] if kwargs["skip_non_music_sections"] else []
-            )
+
+            if kwargs["use_sponsorblock"][0].lower() == "y":
+
+                sponsorblock_postprocessor = [
+                    {
+                        "key": "SponsorBlock",
+                        "categories": ["skip_non_music_sections"],
+                    },
+                    {
+                        "key": "ModifyChapters",
+                        "remove_sponsor_segments": ["music_offtopic"],
+                        "force_keyframes": True,
+                    },
+                ]
 
             file_path = path.join(kwargs["track_db"][i]["save_path"], file_name)
             outtmpl = f"{file_path}.%(ext)s"
@@ -150,17 +162,7 @@ def find_and_download_songs(kwargs):
                 "default_search": "ytsearch",
                 "format": "bestaudio/best",
                 "outtmpl": outtmpl,
-                "postprocessors": [
-                    {
-                        "key": "SponsorBlock",
-                        "categories": sponsorblock_remove_list,
-                    },
-                    {
-                        "key": "ModifyChapters",
-                        "remove_sponsor_segments": ["music_offtopic"],
-                        "force_keyframes": True,
-                    },
-                ],
+                "postprocessors": sponsorblock_postprocessor,
                 "noplaylist": True,
                 "no_color": False,
                 "postprocessor_args": [

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -41,7 +41,7 @@ def test_download_one_false_skip():
         skip_mp3=False,
         keep_playlist_order=False,
         no_overwrites=False,
-        skip_non_music_sections=False,
+        use_sponsorblock="no",
         file_name_f=yt.default_filename,
         multi_core=0,
     )
@@ -49,7 +49,9 @@ def test_download_one_false_skip():
         "Hotel California - Live On MTV, 1994/Eagles - Hotel California - Live On MTV, 1994.mp3",
         ID3=EasyID3,
     )
-    tags = ID3("Hotel California - Live On MTV, 1994/Eagles - Hotel California - Live On MTV, 1994.mp3")
+    tags = ID3(
+        "Hotel California - Live On MTV, 1994/Eagles - Hotel California - Live On MTV, 1994.mp3"
+    )
     assert music["artist"][0] == "Eagles"
     assert music["album"][0] == "Hell Freezes Over (Remaster 2018)"
     assert music["genre"][0] == "album rock"
@@ -92,7 +94,7 @@ def test_download_one_true_skip():
         skip_mp3=True,
         keep_playlist_order=False,
         no_overwrites=False,
-        skip_non_music_sections=False,
+        use_sponsorblock="yes",
         file_name_f=yt.default_filename,
         multi_core=0,
     )
@@ -128,7 +130,7 @@ def test_download_cover_none():
         skip_mp3=False,
         keep_playlist_order=False,
         no_overwrites=False,
-        skip_non_music_sections=False,
+        use_sponsorblock="no",
         file_name_f=yt.default_filename,
         multi_core=0,
     )


### PR DESCRIPTION
Skip sponsorblock by default.

If required, can still be enabled using 

`-s y` or `--use_sponsorblock yes` flag

fixes #309
fixes #281