### PR TITLE
Add max-duration-difference option

### DIFF
--- a/spotify_dl/spotify.py
+++ b/spotify_dl/spotify.py
@@ -25,7 +25,7 @@ def fetch_tracks(sp, item_type, url):
                     fields="items.track.name,items.track.artists(name, uri),"
                     "items.track.album(name, release_date, total_tracks, images),"
                     "items.track.track_number,total, next,offset,"
-                    "items.track.id",
+                    "items.track.id,items.track.duration_ms",
                     additional_types=["track"],
                     offset=offset,
                 )
@@ -47,6 +47,7 @@ def fetch_tracks(sp, item_type, url):
                     track_artist = ",".join(
                         [artist["name"] for artist in track_info.get("artists")]
                     )
+                    track_duration = track_info.get("duration_ms") / 1000
                     if track_album_info:
                         track_album = track_album_info.get("name")
                         track_year = (
@@ -78,6 +79,7 @@ def fetch_tracks(sp, item_type, url):
                             "name": track_name,
                             "artist": track_artist,
                             "album": track_album,
+                            "duration": track_duration,
                             "year": track_year,
                             "num_tracks": album_total,
                             "num": track_num,

--- a/spotify_dl/spotify_dl.py
+++ b/spotify_dl/spotify_dl.py
@@ -112,6 +112,14 @@ def spotify_dl():
         default="",
         help="Download through a proxy. Support HTTP & SOCKS5. Use 'http://username:password@hostname:port' or 'http://hostname:port'",
     )
+    parser.add_argument(
+        "-mdd",
+        "--max-duration-difference",
+        action="store",
+        type=float,
+        default=-1,
+        help="Only download songs that match the track duration up to a maximum difference in seconds",
+    )
     args = parser.parse_args()
     num_cores = os.cpu_count()
     args.multi_core = int(args.multi_core)
@@ -188,6 +196,7 @@ def spotify_dl():
             output_dir=args.output,
             format_str=args.format_str,
             skip_mp3=args.skip_mp3,
+            max_duration_difference=args.max_duration_difference,
             keep_playlist_order=args.keep_playlist_order,
             no_overwrites=args.no_overwrites,
             use_sponsorblock=args.use_sponsorblock,


### PR DESCRIPTION
Add max-duration-difference option to limit the search to matching lengths, as requested in #81. If there is no matching video within the top 10 search results, the download will fail. This seemed to me like a sensible limit, but it can be changed or made a parameter if necessary.