### PR TITLE
detect and parse new intl-xx urls

### DIFF
--- a/spotify_dl/spotify_dl.py
+++ b/spotify_dl/spotify_dl.py
@@ -198,7 +198,7 @@ def spotify_dl():
         )
         url_dict["save_path"].mkdir(parents=True, exist_ok=True)
         log.info("Saving songs to %s directory", directory_name)
-        url_dict["songs"] = fetch_tracks(sp, item_type, url)
+        url_dict["songs"] = fetch_tracks(sp, item_type, item_id)
         url_data["urls"].append(url_dict.copy())
     if args.dump_json is True:
         dump_json(url_dict["songs"])


### PR DESCRIPTION
It seems that Spotify is using a new kind of URL sometimes, where the local language is added to the URL.
Like this:
https://open.spotify.com/intl-de/track/xxx?si=xxx

This pull request does two things:
- Patch `parse_spotify_url` so that it can parse the new `intl-xx` URLs
- rewrite fetch_tracks to use id instead of URL