### PR TITLE
Preferred quality option

### DIFF
--- a/spotify_dl/spotify_dl.py
+++ b/spotify_dl/spotify_dl.py
@@ -131,6 +131,13 @@ def spotify_dl():
         default="",
         help="Download through a proxy. Support HTTP & SOCKS5. Use 'http://username:password@hostname:port' or 'http://hostname:port'",
     )
+    parser.add_argument(
+        "--preferred-quality",
+        action="store",
+        type=str,
+        default="192",
+        help="Set the preferred quality",
+    )
     args = parser.parse_args()
     num_cores = os.cpu_count()
     args.multi_core = int(args.multi_core)
@@ -219,6 +226,7 @@ def spotify_dl():
             file_name_f=file_name_f,
             multi_core=args.multi_core,
             proxy=args.proxy,
+            preferred_quality=args.preferred-quality,
         )
     log.info("Download completed in %.2f seconds.", time.time() - start_time)
 

--- a/spotify_dl/spotify_dl.py
+++ b/spotify_dl/spotify_dl.py
@@ -132,7 +132,7 @@ def spotify_dl():
         help="Download through a proxy. Support HTTP & SOCKS5. Use 'http://username:password@hostname:port' or 'http://hostname:port'",
     )
     parser.add_argument(
-        "--preferred-quality",
+        "--preferred_quality",
         action="store",
         type=str,
         default="192",
@@ -226,7 +226,7 @@ def spotify_dl():
             file_name_f=file_name_f,
             multi_core=args.multi_core,
             proxy=args.proxy,
-            preferred_quality=args.preferred-quality,
+            preferred_quality=args.preferred_quality,
         )
     log.info("Download completed in %.2f seconds.", time.time() - start_time)
 

--- a/spotify_dl/spotify_dl.py
+++ b/spotify_dl/spotify_dl.py
@@ -136,7 +136,7 @@ def spotify_dl():
         action="store",
         type=str,
         default="192",
-        help="Set the preferred quality",
+        help="Set the preferred quality, default is 192",
     )
     args = parser.parse_args()
     num_cores = os.cpu_count()

--- a/spotify_dl/youtube.py
+++ b/spotify_dl/youtube.py
@@ -219,7 +219,7 @@ def find_and_download_songs(kwargs):
                 mp3_postprocess_opts = {
                     "key": "FFmpegExtractAudio",
                     "preferredcodec": "mp3",
-                    "preferredquality": "192",
+                    "preferredquality": kwargs.get("preferred_quality"),
                 }
                 ydl_opts["postprocessors"].append(mp3_postprocess_opts.copy())
             with yt_dlp.YoutubeDL(ydl_opts) as ydl:


### PR DESCRIPTION
This is to allow different audio file qualities, rather than the hard-coded 192.
Adds an optional argument with a default of 192.

Tested with and without the argument.