### PR TITLE
Two minor fixes

### DIFF
--- a/spotify_dl/youtube.py
+++ b/spotify_dl/youtube.py
@@ -343,8 +343,9 @@ def download_songs(**kwargs):
         log.debug("Downloading to %s", url["save_path"])
     reference_file = DOWNLOAD_LIST
     track_db = write_tracks(reference_file, kwargs["songs"])
-    shutil.copy(reference_file, kwargs["output_dir"] + "/" + reference_file)
-    os.remove(reference_file)
+    if not shutil._samefile(reference_file, kwargs["output_dir"] + "/" + reference_file):
+        shutil.copy(reference_file, kwargs["output_dir"] + "/" + reference_file)
+        os.remove(reference_file)
     reference_file = str(kwargs["output_dir"]) + "/" + reference_file
     kwargs["reference_file"] = reference_file
     kwargs["track_db"] = track_db

--- a/spotify_dl/youtube.py
+++ b/spotify_dl/youtube.py
@@ -46,9 +46,13 @@ def dump_json(songs):
                 ytJson = {}
                 with ytmusicapi.YTMusic() as ym:
                     # Reduce results to array of titles and video IDs
+                    search_results = ym.search(query, filter="songs")
+                    if len(search_results) == 0:
+                        log.error(f"No results found for {query}, skipping.")
+                        continue
                     result_titles, result_ids = zip(*map(
                         lambda d: (f"{d['artists'][0]['name']} - {d['title']}".replace(":", "").replace('"', ""), d["videoId"]),
-                        ym.search(query, filter="songs")
+                        search_results
                     ))
                     # Get ID of closest matching result by finding index in titles list
                     videoId = result_ids[result_titles.index(get_closest_match(result_titles, query))]
@@ -214,9 +218,13 @@ def find_and_download_songs(kwargs):
 
             with ytmusicapi.YTMusic() as ym:
                 # Reduce search results to array of titles and video IDs
+                search_results = ym.search(query, filter="songs")
+                if len(search_results) == 0:
+                    log.error(f"No results found for {query}, skipping.")
+                    continue
                 result_titles, result_ids = zip(*map(
                     lambda d: (f"{d['artists'][0]['name']} - {d['title']}".replace(":", "").replace('"', ""), d["videoId"]),
-                    ym.search(query, filter="songs")
+                    search_results
                 ))
                 # Get ID of closest matching result by finding index in titles list
                 video_id = result_ids[result_titles.index(get_closest_match(result_titles, query))]

--- a/spotify_dl/youtube.py
+++ b/spotify_dl/youtube.py
@@ -48,8 +48,11 @@ def dump_json(songs):
                     # Reduce results to array of titles and video IDs
                     search_results = ym.search(query, filter="songs")
                     if len(search_results) == 0:
-                        log.error(f"No results found for {query}, skipping.")
-                        continue
+                        log.warning("No song results found for %s, retrying.", query)
+                        search_results = ym.search(query, filter="videos")
+                        if len(search_results) == 0:
+                            log.error("No search results found for %s, skipping.", query)
+                            continue
                     result_titles, result_ids = zip(*map(
                         lambda d: (f"{d['artists'][0]['name']} - {d['title']}".replace(":", "").replace('"', ""), d["videoId"]),
                         search_results
@@ -220,8 +223,11 @@ def find_and_download_songs(kwargs):
                 # Reduce search results to array of titles and video IDs
                 search_results = ym.search(query, filter="songs")
                 if len(search_results) == 0:
-                    log.error(f"No results found for {query}, skipping.")
-                    continue
+                    log.warning("No song results found for %s, retrying.", query)
+                    search_results = ym.search(query, filter="videos")
+                    if len(search_results) == 0:
+                        log.error("No search results found for %s, skipping.", query)
+                        continue
                 result_titles, result_ids = zip(*map(
                     lambda d: (f"{d['artists'][0]['name']} - {d['title']}".replace(":", "").replace('"', ""), d["videoId"]),
                     search_results


### PR DESCRIPTION
I'm somewhat ashamed to have made such a trivial oversight, but yet here I am. This PR:
- fixes a crash when no search results are found for a song by retrying without the "songs only" filter (introduced by #375).

On top of that, included is a fix for https://github.com/Maritsu/spotify-dl/commit/e05d9e444beb6a6e5095aa315b5dcc40c02c8d12#commitcomment-144139425 (`shutil.SameFileError` when moving reference log).