### PR TITLE
Prevent empty folder from being created when dumping JSON

### DIFF
--- a/spotify_dl/spotify_dl.py
+++ b/spotify_dl/spotify_dl.py
@@ -196,8 +196,10 @@ def spotify_dl():
         url_dict["save_path"] = Path(
             PurePath.joinpath(Path(args.output), Path(directory_name))
         )
-        url_dict["save_path"].mkdir(parents=True, exist_ok=True)
-        log.info("Saving songs to %s directory", directory_name)
+        # Prevent empty folder from being created when dumping JSON
+        if args.dump_json is False:
+            url_dict["save_path"].mkdir(parents=True, exist_ok=True)
+            log.info("Saving songs to %s directory", directory_name)
         url_dict["songs"] = fetch_tracks(sp, item_type, item_id)
         url_data["urls"].append(url_dict.copy())
     if args.dump_json is True:


### PR DESCRIPTION
At the moment an empty folder will be created, even when executing the command with the ``--dump-json`` flag.