### PR TITLE
Remove tempo information feature

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ mutagen~=1.45
 rich~=12.0
 urllib3~=1.26
 ytmusicapi~=1.6.0
-Levenshtein~=0.25.1
+Levenshtein~=0.27.3

--- a/spotify_dl/spotify.py
+++ b/spotify_dl/spotify.py
@@ -42,14 +42,8 @@ def fetch_tracks(sp, item_type, item_id):
                         continue
                     track_album_info = track_info.get("album")
                     track_num = track_info.get("track_number")
-                    track_name = track_info.get("name")
                     spotify_id = track_info.get("id")
-                    try:
-                        track_audio_data = sp.audio_analysis(spotify_id)
-                        tempo = track_audio_data.get("track").get("tempo")
-                    except:
-                        log.error("Couldn't fetch audio analysis for %s", track_name)
-                        tempo = None
+                    track_name = track_info.get("name")
                     track_artist = ", ".join(
                         [artist["name"] for artist in track_info.get("artists")]
                     )
@@ -92,7 +86,6 @@ def fetch_tracks(sp, item_type, item_id):
                             "genre": genre,
                             "spotify_id": spotify_id,
                             "track_url": None,
-                            "tempo": tempo,
                         }
                     )
                     offset += 1
@@ -148,12 +141,6 @@ def fetch_tracks(sp, item_type, item_id):
                     )
                     track_num = item["track_number"]
                     spotify_id = item.get("id")
-                    try:
-                        track_audio_data = sp.audio_analysis(spotify_id)
-                        tempo = track_audio_data.get("track").get("tempo")
-                    except:
-                        log.error("Couldn't fetch audio analysis for %s", track_name)
-                        tempo = None
                     songs_list.append(
                         {
                             "name": track_name,
@@ -167,7 +154,6 @@ def fetch_tracks(sp, item_type, item_id):
                             "cover": cover,
                             "genre": genre,
                             "spotify_id": spotify_id,
-                            "tempo": tempo,
                         }
                     )
                     offset += 1
@@ -196,12 +182,6 @@ def fetch_tracks(sp, item_type, item_id):
             album_total = album_info.get("total_tracks")
         track_num = items["track_number"]
         spotify_id = items["id"]
-        try:
-            track_audio_data = sp.audio_analysis(spotify_id)
-            tempo = track_audio_data.get("track").get("tempo")
-        except:
-            log.error("Couldn't fetch audio analysis for %s", track_name)
-            tempo = None
         if len(items["album"]["images"]) > 0:
             cover = items["album"]["images"][0]["url"]
         else:
@@ -223,7 +203,6 @@ def fetch_tracks(sp, item_type, item_id):
                 "genre": genre,
                 "track_url": None,
                 "spotify_id": spotify_id,
-                "tempo": tempo,
             }
         )
 

--- a/spotify_dl/youtube.py
+++ b/spotify_dl/youtube.py
@@ -83,13 +83,13 @@ def write_tracks(tracks_file, song_dict):
         i = 0
         writer = csv.writer(file_out, delimiter=";")
         for url_dict in song_dict["urls"]:
+            # for track in url_dict['songs']:
             for track in url_dict["songs"]:
                 track_url = track["track_url"]  # here
                 track_name = track["name"]
                 track_artist = track["artist"]
                 track_num = track["num"]
                 track_album = track["album"]
-                track_tempo = track["tempo"]
                 track["save_path"] = url_dict["save_path"]
                 track_db.append(track)
                 track_index = i
@@ -100,7 +100,6 @@ def write_tracks(tracks_file, song_dict):
                     track_url,
                     str(track_num),
                     track_album,
-                    str(track_tempo),
                     str(track_index),
                 ]
                 try:
@@ -139,8 +138,6 @@ def set_tags(temp, filename, kwargs):
         )
 
     song_file["genre"] = song.get("genre")
-    if song.get("tempo") is not None:
-        song_file["bpm"] = str(song.get("tempo"))
     song_file.save()
     song_file = MP3(filename, ID3=ID3)
     cover = song.get("cover")

--- a/tests/test_spotify_fetch_tracks.py
+++ b/tests/test_spotify_fetch_tracks.py
@@ -32,7 +32,6 @@ def test_spotify_playlist_fetch_one():
         "track_url": None,
         "playlist_num": 1,
         "spotify_id": "2GpBrAoCwt48fxjgjlzMd4",
-        'tempo': 74.656,
     } == songs[0]
 
 
@@ -54,7 +53,6 @@ def test_spotify_playlist_fetch_more():
             "year": "2012",
             "playlist_num": 1,
             "spotify_id": "4rzfv0JLZfVhOhbSQ8o5jZ",
-            'tempo': 135.016,
         },
         {
             "album": "Wellness & Dreaming Source",
@@ -68,7 +66,6 @@ def test_spotify_playlist_fetch_more():
             "playlist_num": 2,
             "track_url": None,
             "spotify_id": "5o3jMYOSbaVz3tkgwhELSV",
-            'tempo': 137.805,
         },
         {
             "album": "This Is Happening",
@@ -82,7 +79,6 @@ def test_spotify_playlist_fetch_more():
             "year": "2010",
             "playlist_num": 3,
             "spotify_id": "4Cy0NHJ8Gh0xMdwyM9RkQm",
-            'tempo': 134.99,
         },
         {
             "album": "Glenn Horiuchi Trio / Gelenn Horiuchi Quartet: Mercy / Jump Start "
@@ -98,7 +94,6 @@ def test_spotify_playlist_fetch_more():
             "track_url": None,
             "playlist_num": 4,
             "spotify_id": "6hvFrZNocdt2FcKGCSY5NI",
-            'tempo': 114.767,
         },
         {
             "album": "All The Best (Spanish Version)",
@@ -112,7 +107,6 @@ def test_spotify_playlist_fetch_more():
             "year": "2007",
             "playlist_num": 5,
             "spotify_id": "2E2znCPaS8anQe21GLxcvJ",
-            'tempo': 122.318,
         },
     ] == songs
 
@@ -134,7 +128,6 @@ def test_spotify_track_fetch_one():
         "track_url": None,
         "playlist_num": 1,
         "spotify_id": "2GpBrAoCwt48fxjgjlzMd4",
-        'tempo': 74.656,
     } == songs[0]
 
 
@@ -155,7 +148,6 @@ def test_spotify_album_fetch_one():
         "year": "2012",
         "playlist_num": 1,
         "spotify_id": "5EoKQDGE2zxrTfRFZF52u5",
-        'tempo': 120.009,
     } == songs[0]
 
 
@@ -177,7 +169,6 @@ def test_spotify_album_fetch_more():
             "year": "1974",
             "playlist_num": 1,
             "spotify_id": "69Yw7H4bRIwfIxL0ZCZy8y",
-            'tempo': 120.955,
         },
         {
             "album": "Queen II (Deluxe Remastered Version)",
@@ -191,7 +182,6 @@ def test_spotify_album_fetch_more():
             "year": "1974",
             "playlist_num": 2,
             "spotify_id": "5GGSjXZeTgX9sKYBtl8K6U",
-            'tempo': 147.384,
         },
         {
             "album": "Queen II (Deluxe Remastered Version)",
@@ -205,7 +195,6 @@ def test_spotify_album_fetch_more():
             "year": "1974",
             "playlist_num": 3,
             "spotify_id": "0Ssh20fuVhmasLRJ97MLnp",
-            'tempo': 152.769,
         },
         {
             "album": "Queen II (Deluxe Remastered Version)",
@@ -219,7 +208,6 @@ def test_spotify_album_fetch_more():
             "year": "1974",
             "playlist_num": 4,
             "spotify_id": "2LasW39KJDE4VH9hTVNpE2",
-            'tempo': 115.471,
         },
         {
             "album": "Queen II (Deluxe Remastered Version)",
@@ -233,7 +221,6 @@ def test_spotify_album_fetch_more():
             "year": "1974",
             "playlist_num": 5,
             "spotify_id": "6jXrIu3hWbmJziw34IHIwM",
-            'tempo': 145.124,
         },
         {
             "album": "Queen II (Deluxe Remastered Version)",
@@ -247,7 +234,6 @@ def test_spotify_album_fetch_more():
             "track_url": None,
             "playlist_num": 6,
             "spotify_id": "5dHmGuUeRgp5f93G69tox5",
-            'tempo': 108.544,
         },
         {
             "album": "Queen II (Deluxe Remastered Version)",
@@ -261,7 +247,6 @@ def test_spotify_album_fetch_more():
             "year": "1974",
             "playlist_num": 7,
             "spotify_id": "2KPj0oB7cUuHQ3FuardOII",
-            'tempo': 159.156,
         },
         {
             "album": "Queen II (Deluxe Remastered Version)",
@@ -275,7 +260,6 @@ def test_spotify_album_fetch_more():
             "year": "1974",
             "playlist_num": 8,
             "spotify_id": "34CcBjL9WqEAtnl2i6Hbxa",
-            'tempo': 118.48,
         },
         {
             "album": "Queen II (Deluxe Remastered Version)",
@@ -289,7 +273,6 @@ def test_spotify_album_fetch_more():
             "year": "1974",
             "playlist_num": 9,
             "spotify_id": "1x9ak6LGIazLhfuaSIEkhG",
-            'tempo': 112.623,
         },
         {
             "album": "Queen II (Deluxe Remastered Version)",
@@ -303,7 +286,6 @@ def test_spotify_album_fetch_more():
             "year": "1974",
             "playlist_num": 10,
             "spotify_id": "4CITL18Tos0PscW1amCK4j",
-            'tempo': 145.497,
         },
         {
             "album": "Queen II (Deluxe Remastered Version)",
@@ -317,7 +299,6 @@ def test_spotify_album_fetch_more():
             "year": "1974",
             "playlist_num": 11,
             "spotify_id": "1e9Tt3nKBwRbuaU79kN3dn",
-            'tempo': 126.343,
         },
         {
             "album": "Queen II (Deluxe Remastered Version)",
@@ -331,7 +312,6 @@ def test_spotify_album_fetch_more():
             "year": "1974",
             "playlist_num": 12,
             "spotify_id": "0uHqoDT7J2TYBsJx6m4Tvi",
-            'tempo': 172.274,
         },
         {
             "album": "Queen II (Deluxe Remastered Version)",
@@ -345,8 +325,6 @@ def test_spotify_album_fetch_more():
             "year": "1974",
             "playlist_num": 13,
             "spotify_id": "3MIueGYoNiyBNfi5ukDgAK",
-            'tempo': 146.712,
-
         },
         {
             "album": "Queen II (Deluxe Remastered Version)",
@@ -360,7 +338,6 @@ def test_spotify_album_fetch_more():
             "year": "1974",
             "playlist_num": 14,
             "spotify_id": "34WAOFWdJ83a3YYrDAZTjm",
-            'tempo': 128.873,
         },
         {
             "album": "Queen II (Deluxe Remastered Version)",
@@ -374,7 +351,6 @@ def test_spotify_album_fetch_more():
             "year": "1974",
             "playlist_num": 15,
             "spotify_id": "2AFIPUlApcUwGEgOSDwoBz",
-            'tempo': 122.986,
         },
         {
             "album": "Queen II (Deluxe Remastered Version)",
@@ -388,7 +364,6 @@ def test_spotify_album_fetch_more():
             "year": "1974",
             "playlist_num": 16,
             "spotify_id": "4G4Sf18XkFvNTV5vAxiQyd",
-            'tempo': 169.166,
         },
     ] == songs
     assert (len(songs)) == 16
@@ -412,6 +387,5 @@ def test_spotify_playlist_fetch_local_file():
             "year": "",
             "playlist_num": 1,
             "spotify_id": None,
-            "tempo": None, 
         }
     ] == songs

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -28,7 +28,6 @@ def test_download_one_false_skip():
                         "cover": "https://i.scdn.co/image/ab67616d0000b27396d28597a5ae44ab66552183",
                         "genre": "album rock",
                         "spotify_id": "2GpBrAoCwt48fxjgjlzMd4",
-                        'tempo': 74.656,
                     }
                 ],
             }
@@ -84,7 +83,6 @@ def test_download_one_true_skip():
                         "cover": "https://i.scdn.co/image/ab67616d0000b27396d28597a5ae44ab66552183",
                         "genre": "album rock",
                         "spotify_id": "2GpBrAoCwt48fxjgjlzMd4",
-                        'tempo': 74.656,
                     }
                 ],
             }
@@ -122,7 +120,6 @@ def test_download_cover_none():
                         "cover": None,
                         "genre": "classic rock",
                         "spotify_id": "12LhScrlYazmU4vsqpRQNI",
-                        'tempo': 159.15,
                     }
                 ],
             }


### PR DESCRIPTION
Tempo information was added to spotify_dl in January 2024 via a0d4bcc8ae65d9dd0c38a2d536c38b07d9a159cd

The API for that information does not exist anymore (deprecated November 2024 https://developer.spotify.com/blog/2024-11-27-changes-to-the-web-api ) and spotify_dl therefore always shows an error. This error also disrupted the JSON output since it used the wrong loglevel. Instead of fixing that I propose to just reverse the feature since it can't be used anymore anyways.

This pull request also bumps the Levenshtein version to 0.27.3 to work on Python 3.14

Fixes #386 and #384
